### PR TITLE
Stable window snap

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -883,6 +883,11 @@
         "assert-plus": "^1.0.0"
       }
     },
+    "debounce": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.0.tgz",
+      "integrity": "sha512-mYtLl1xfZLi1m4RtQYlZgJUNQjl4ZxVnHzIR8nLLgi4q1YT8o/WM+MK/f8yfcc9s5Ir5zRaPZyZU6xs1Syoocg=="
+    },
     "debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -2441,8 +2446,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/imul/-/imul-1.0.1.tgz",
       "integrity": "sha1-nVhnFh6LPelsLDjV3HyxAvNeKsk=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "imurmurhash": {
       "version": "0.1.4",
@@ -2735,8 +2739,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
       "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "is-regex": {
       "version": "1.0.4",
@@ -3302,8 +3305,7 @@
       "version": "2.11.1",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.1.tgz",
       "integrity": "sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "nanomatch": {
       "version": "1.2.13",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "sinon": "^7.1.1"
   },
   "dependencies": {
+    "debounce": "^1.2.0",
     "uuid": "^3.2.1"
   }
 }

--- a/src/windows/windows.js
+++ b/src/windows/windows.js
@@ -5,6 +5,10 @@ const path = require('path')
 
 let timerWindow, configWindow, fullscreenWindow
 let snapThreshold, secondsUntilFullscreen, timerAlwaysOnTop
+const timerWindowSize = {
+  width: 220,
+  height: 90
+}
 
 exports.createTimerWindow = () => {
   if (timerWindow) {
@@ -13,10 +17,10 @@ exports.createTimerWindow = () => {
 
   let { width, height } = electron.screen.getPrimaryDisplay().workAreaSize
   timerWindow = new electron.BrowserWindow({
-    x: width - 220,
-    y: height - 90,
-    width: 220,
-    height: 90,
+    x: width - timerWindowSize.width,
+    y: height - timerWindowSize.height,
+    width: timerWindowSize.width,
+    height: timerWindowSize.height,
     resizable: false,
     alwaysOnTop: timerAlwaysOnTop,
     frame: false,
@@ -43,7 +47,12 @@ exports.createTimerWindow = () => {
 
     let snapTo = windowSnapper(windowBounds, screenBounds, snapThreshold)
     if (snapTo.x !== windowBounds.x || snapTo.y !== windowBounds.y) {
-      timerWindow.setPosition(snapTo.x, snapTo.y)
+      timerWindow.setBounds({
+        width: timerWindowSize.width,
+        height: timerWindowSize.height,
+        x: snapTo.x,
+        y: snapTo.y
+      })
     }
   })
 }

--- a/src/windows/windows.js
+++ b/src/windows/windows.js
@@ -2,6 +2,7 @@ const electron = require('electron')
 const { app } = electron
 const windowSnapper = require('./window-snapper')
 const path = require('path')
+const { debounce } = require('debounce')
 
 let timerWindow, configWindow, fullscreenWindow
 let snapThreshold, secondsUntilFullscreen, timerAlwaysOnTop
@@ -29,6 +30,7 @@ exports.createTimerWindow = () => {
 
   timerWindow.loadURL(`file://${__dirname}/timer/index.html`)
   timerWindow.on('closed', () => (timerWindow = null))
+  const delayedSetBounds = debounce(timerWindow.setBounds, 100)
 
   timerWindow.on('move', () => {
     if (snapThreshold <= 0) {
@@ -47,12 +49,14 @@ exports.createTimerWindow = () => {
 
     let snapTo = windowSnapper(windowBounds, screenBounds, snapThreshold)
     if (snapTo.x !== windowBounds.x || snapTo.y !== windowBounds.y) {
-      timerWindow.setBounds({
+      delayedSetBounds({
         width: timerWindowSize.width,
         height: timerWindowSize.height,
         x: snapTo.x,
         y: snapTo.y
       })
+    } else {
+      delayedSetBounds.clear()
     }
   })
 }


### PR DESCRIPTION
# Problem

When window snaps on Windows the timerWindow size changes and becomes bigger

# Solution

- Use [BrowserWindow.setBounds](https://electronjs.org/docs/api/browser-window#winsetboundsbounds-animate) where this issue seems to not happen.
- Debounce the snap function to avoid "getting stuck" against a workspace edge.