### PR TITLE
Correct information in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "name": "mob-timer",
-  "version": "1.0.0",
   "description": "A cross-platform mob-timer built on Electron for doing Mob Programming.",
   "main": "src/main.js",
   "scripts": {
@@ -21,6 +20,7 @@
   },
   "author": "",
   "license": "Apache-2.0",
+  "private": true,
   "bugs": {
     "url": "https://github.com/mob-timer/mob-timer/issues"
   },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mob-timer",
   "version": "1.0.0",
-  "description": "",
+  "description": "A cross-platform mob-timer built on Electron for doing Mob Programming.",
   "main": "src/main.js",
   "scripts": {
     "start": "electron .",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "url": "git+https://github.com/mob-timer/mob-timer.git"
   },
   "author": "",
-  "license": "ISC",
+  "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/mob-timer/mob-timer/issues"
   },

--- a/package.json
+++ b/package.json
@@ -17,14 +17,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/pluralsight/mob-timer.git"
+    "url": "git+https://github.com/mob-timer/mob-timer.git"
   },
   "author": "",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/pluralsight/mob-timer/issues"
+    "url": "https://github.com/mob-timer/mob-timer/issues"
   },
-  "homepage": "https://github.com/pluralsight/mob-timer#readme",
+  "homepage": "https://mob-timer.github.io",
   "devDependencies": {
     "electron": "^4.0.4",
     "electron-installer-dmg": "^2.0.0",


### PR DESCRIPTION
As a developer
In order to not be confused when looking into `package.json`
I want the information to be correct

As a developer
In order to reduce the risk of accidental publish to `npm`
I want the system to stop me from publishing

# Changes

- Adjust links to repository and homepage
- Match license property with `LICENCE`
- Add description
- Avoid accidental publish to `npm`

# Room for improvements

## `dependencies` vs `devDependencies`

I'm a little bit confused if we have our packages in the correct place, `dependencies` vs `devDependencies`. Maybe all our things should be in `devDependencies` due to `electron` re-packaging everything? Or maybe `electron` should be moved from `devDependencies` to `dependencies`?

[StackOverflow: Why does Electron need to be saved as a developer dependency?](https://stackoverflow.com/questions/50803207/why-does-electron-need-to-be-saved-as-a-developer-dependency)
