### PR TITLE
Avoid decompress-zip high vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -910,9 +910,9 @@
       "dev": true
     },
     "decompress-zip": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/decompress-zip/-/decompress-zip-0.3.0.tgz",
-      "integrity": "sha1-rjvLfjTGWHmt/nfhnDD4ZgK0vbA=",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/decompress-zip/-/decompress-zip-0.3.2.tgz",
+      "integrity": "sha512-Ab1QY4LrWMrUuo53lLnmGOby7v8ryqxJ+bKibKSiPisx+25mhut1dScVBXAYx14i/PqSrFZvR2FRRazhLbvL+g==",
       "dev": true,
       "requires": {
         "binary": "^0.3.0",
@@ -3186,12 +3186,12 @@
       "dev": true
     },
     "mksnapshot": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/mksnapshot/-/mksnapshot-0.3.4.tgz",
-      "integrity": "sha512-FgUTiWiY+35LgL95P/MDYrBuQO5o0s3MmaWKX6ZJWoX4vMOY9vPsAv763l1OSSelL9jPsBQ/wf4bzfqTLNPSFg==",
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/mksnapshot/-/mksnapshot-0.3.5.tgz",
+      "integrity": "sha512-PSBoZaj9h9myC3uRRW62RxmX8mrN3XbOkMEyURUD7v5CeJgtYTar50XU738t7Q0LtG1pBPtp5n5QwDGggRnEvw==",
       "dev": true,
       "requires": {
-        "decompress-zip": "0.3.0",
+        "decompress-zip": "0.3.x",
         "fs-extra": "0.26.7",
         "request": "2.x"
       },


### PR DESCRIPTION
Found with 'npm audit', fixed with 'npm audit fix'

```
=== npm audit security report ===

# Run  npm update mksnapshot --depth 3  to resolve 1 vulnerability

  High            Arbitrary File Overwrite

  Package         decompress-zip

  Dependency of   electron-packager [dev]

  Path            electron-packager > asar > mksnapshot > decompress-zip

  More info       https://nodesecurity.io/advisories/777



found 1 high severity vulnerability in 2134 scanned packages
  run `npm audit fix` to fix 1 of them.
```