### PR TITLE
Coveralls

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![License](https://img.shields.io/github/license/mob-timer/mob-timer.svg)](LICENSE)
 [![GitHub contributors](https://img.shields.io/github/contributors/mob-timer/mob-timer.svg)](https://github.com/mob-timer/mob-timer/graphs/contributors)
 [![Travis (.org)](https://img.shields.io/travis/mob-timer/mob-timer/master.svg)](https://travis-ci.org/mob-timer/mob-timer/branches)
+[![Coverage Status](https://coveralls.io/repos/github/mob-timer/mob-timer/badge.svg?branch=master)](https://coveralls.io/github/mob-timer/mob-timer?branch=master)
 ![GitHub All Releases](https://img.shields.io/github/downloads/mob-timer/mob-timer/total.svg)
 [![GitHub open idea issues](https://img.shields.io/github/issues-raw/mob-timer/mob-timer/idea.svg?color=blue)](https://github.com/mob-timer/mob-timer/issues?q=is%3Aissue+is%3Aopen+label%3Aidea)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -887,6 +887,20 @@
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
     },
+    "coveralls": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.0.3.tgz",
+      "integrity": "sha512-viNfeGlda2zJr8Gj1zqXpDMRjw9uM54p7wzZdvLRyOgnAfCe974Dq4veZkjJdxQXbmdppu6flEajFYseHYaUhg==",
+      "dev": true,
+      "requires": {
+        "growl": "~> 1.10.0",
+        "js-yaml": "^3.11.0",
+        "lcov-parse": "^0.0.10",
+        "log-driver": "^1.2.7",
+        "minimist": "^1.2.0",
+        "request": "^2.86.0"
+      }
+    },
     "cp-file": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/cp-file/-/cp-file-3.2.0.tgz",
@@ -3056,6 +3070,12 @@
         "invert-kv": "^2.0.0"
       }
     },
+    "lcov-parse": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-0.0.10.tgz",
+      "integrity": "sha1-GwuP+ayceIklBYK3C3ExXZ2m2aM=",
+      "dev": true
+    },
     "levn": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
@@ -3107,6 +3127,12 @@
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
       "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+      "dev": true
+    },
+    "log-driver": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.7.tgz",
+      "integrity": "sha512-U7KCmLdqsGHBLeWqYlFA0V0Sl6P08EE1ZrmA9cxjUE0WVqT9qnyVDPz1kzpFEP0jdJuFnasWIfSd7fsaNXkpbg==",
       "dev": true
     },
     "log-symbols": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   },
   "homepage": "https://mob-timer.github.io",
   "devDependencies": {
+    "coveralls": "^3.0.3",
     "electron": "^4.0.4",
     "electron-installer-dmg": "^2.0.0",
     "electron-packager": "^13.0.1",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
   "nyc": {
     "exclude": [
       "**/*.specs.js",
-      "test/**/*.*"
+      "test/**/*.*",
+      "dist/**/*.*"
     ],
     "reporter": [
       "text-summary"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test": "mocha --use_strict --recursive",
     "tdd": "mocha --use_strict --recursive -w",
     "watch": "mocha --use_strict --recursive -w",
-    "coverage": "nyc mocha --use_strict --recursive"
+    "coverage": "nyc mocha --use_strict --recursive && nyc report --reporter=text-lcov | coveralls"
   },
   "nyc": {
     "exclude": [

--- a/test/windows/window-snapper.specs.js
+++ b/test/windows/window-snapper.specs.js
@@ -1,0 +1,12 @@
+const windowSnapper = require('../../src/windows/window-snapper')
+const assert = require('assert')
+
+describe('window-snapper', () => {
+  it('should return window coordinates if threshold is 0', () => {
+    const windowBounds = { x: 0, y: 0, width: 1920, height: 1080 }
+    const screenBounds = {}
+    const snapThreshold = 0
+    const result = windowSnapper(windowBounds, screenBounds, snapThreshold)
+    assert.deepStrictEqual(result, { x: 0, y: 0 })
+  })
+})


### PR DESCRIPTION
**As** a developer
**In order to** promote good test coverage and quality thinking
**I want** a dynamic code coverage shield in the README, coverage over time, feedback in PRs regarding coverage

#12

# What

- Push `nyc` report to `coveralls` with [`node-coveralls`](https://docs.coveralls.io/javascript), [travis ci does the handshake automatically](https://docs.coveralls.io/supported-ci-services)
- Enable "comment on PR", not active or this PR, might be due to no collected coverage in `master`. 
    ![image](https://user-images.githubusercontent.com/2315367/54496569-0cc3fd80-48f1-11e9-961f-0d569a3c6e4d.png)
- Enable "Use API" and set some really soft thresholds.
    ![image](https://user-images.githubusercontent.com/2315367/54496551-edc56b80-48f0-11e9-8e98-3979a5b885b1.png)

- Add coverage badge to README
    ![image](https://user-images.githubusercontent.com/2315367/54496600-675d5980-48f1-11e9-9690-8bf401b474fd.png)
