### PR TITLE
Move window snap details into window-snapper

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,8 @@
 {
   "name": "mob-timer",
+  "engines": {
+    "node": "10.11.0"
+  },
   "description": "A cross-platform mob-timer built on Electron for doing Mob Programming.",
   "main": "src/main.js",
   "scripts": {

--- a/src/windows/window-snapper.js
+++ b/src/windows/window-snapper.js
@@ -1,9 +1,9 @@
-const isCloseTo = (a, b, snapThreshold) => {
+const setupThresholdCheck = snapThreshold => (a, b) => {
   return Math.abs(a - b) <= snapThreshold
 }
 
-const snapLeftCheck = (windowBounds, screenBounds, snapThreshold) => {
-  if (isCloseTo(windowBounds.x, screenBounds.x, snapThreshold)) {
+const snapLeftCheck = (windowBounds, screenBounds, isWithinThreshold) => {
+  if (isWithinThreshold(windowBounds.x, screenBounds.x)) {
     return {
       x: screenBounds.x,
       shouldSnap: true
@@ -12,10 +12,10 @@ const snapLeftCheck = (windowBounds, screenBounds, snapThreshold) => {
   return {}
 }
 
-const snapRightCheck = (windowBounds, screenBounds, snapThreshold) => {
+const snapRightCheck = (windowBounds, screenBounds, isWithinThreshold) => {
   const rightWindowEdge = windowBounds.x + windowBounds.width
   const rightScreenEdge = screenBounds.x + screenBounds.width
-  if (isCloseTo(rightWindowEdge, rightScreenEdge, snapThreshold)) {
+  if (isWithinThreshold(rightWindowEdge, rightScreenEdge)) {
     return {
       x: rightScreenEdge - windowBounds.width,
       shouldSnap: true
@@ -24,8 +24,8 @@ const snapRightCheck = (windowBounds, screenBounds, snapThreshold) => {
   return {}
 }
 
-const snapTopCheck = (windowBounds, screenBounds, snapThreshold) => {
-  if (isCloseTo(windowBounds.y, screenBounds.y, snapThreshold)) {
+const snapTopCheck = (windowBounds, screenBounds, isWithinThreshold) => {
+  if (isWithinThreshold(windowBounds.y, screenBounds.y)) {
     return {
       y: screenBounds.y,
       shouldSnap: true
@@ -34,10 +34,10 @@ const snapTopCheck = (windowBounds, screenBounds, snapThreshold) => {
   return {}
 }
 
-const snapBottomCheck = (windowBounds, screenBounds, snapThreshold) => {
+const snapBottomCheck = (windowBounds, screenBounds, isWithinThreshold) => {
   const bottomWindowEdge = windowBounds.y + windowBounds.height
   const bottomScreenEdge = screenBounds.y + screenBounds.height
-  if (isCloseTo(bottomWindowEdge, bottomScreenEdge, snapThreshold)) {
+  if (isWithinThreshold(bottomWindowEdge, bottomScreenEdge)) {
     return {
       y: bottomScreenEdge - windowBounds.height,
       shouldSnap: true
@@ -47,17 +47,18 @@ const snapBottomCheck = (windowBounds, screenBounds, snapThreshold) => {
 }
 
 module.exports = (windowBounds, screenBounds, snapThreshold) => {
+  const noSnap = { x: windowBounds.x, y: windowBounds.y, shouldSnap: false }
   if (snapThreshold <= 0) {
-    return { x: windowBounds.x, y: windowBounds.y, shouldSnap: false }
+    return noSnap
   }
 
+  const isWithinThreshold = setupThresholdCheck(snapThreshold)
+
   return {
-    x: windowBounds.x,
-    y: windowBounds.y,
-    shouldSnap: false,
-    ...snapLeftCheck(windowBounds, screenBounds, snapThreshold),
-    ...snapRightCheck(windowBounds, screenBounds, snapThreshold),
-    ...snapTopCheck(windowBounds, screenBounds, snapThreshold),
-    ...snapBottomCheck(windowBounds, screenBounds, snapThreshold)
+    ...noSnap,
+    ...snapLeftCheck(windowBounds, screenBounds, isWithinThreshold),
+    ...snapRightCheck(windowBounds, screenBounds, isWithinThreshold),
+    ...snapTopCheck(windowBounds, screenBounds, isWithinThreshold),
+    ...snapBottomCheck(windowBounds, screenBounds, isWithinThreshold)
   }
 }

--- a/src/windows/window-snapper.js
+++ b/src/windows/window-snapper.js
@@ -49,4 +49,4 @@ const snapBottomCheck = (windowBounds, screenBounds, isWithinThreshold) => {
   } : undefined
 }
 
-module.exports = snapCheck
+module.exports = { snapCheck }

--- a/src/windows/window-snapper.js
+++ b/src/windows/window-snapper.js
@@ -1,3 +1,20 @@
+const snapCheck = (windowBounds, screenBounds, snapThreshold) => {
+  const noSnap = { x: windowBounds.x, y: windowBounds.y, shouldSnap: false }
+  if (snapThreshold <= 0) {
+    return noSnap
+  }
+
+  const isWithinThreshold = setupThresholdCheck(snapThreshold)
+
+  return {
+    ...noSnap,
+    ...snapLeftCheck(windowBounds, screenBounds, isWithinThreshold),
+    ...snapRightCheck(windowBounds, screenBounds, isWithinThreshold),
+    ...snapTopCheck(windowBounds, screenBounds, isWithinThreshold),
+    ...snapBottomCheck(windowBounds, screenBounds, isWithinThreshold)
+  }
+}
+
 const setupThresholdCheck = snapThreshold => (a, b) => {
   return Math.abs(a - b) <= snapThreshold
 }
@@ -46,19 +63,4 @@ const snapBottomCheck = (windowBounds, screenBounds, isWithinThreshold) => {
   return {}
 }
 
-module.exports = (windowBounds, screenBounds, snapThreshold) => {
-  const noSnap = { x: windowBounds.x, y: windowBounds.y, shouldSnap: false }
-  if (snapThreshold <= 0) {
-    return noSnap
-  }
-
-  const isWithinThreshold = setupThresholdCheck(snapThreshold)
-
-  return {
-    ...noSnap,
-    ...snapLeftCheck(windowBounds, screenBounds, isWithinThreshold),
-    ...snapRightCheck(windowBounds, screenBounds, isWithinThreshold),
-    ...snapTopCheck(windowBounds, screenBounds, isWithinThreshold),
-    ...snapBottomCheck(windowBounds, screenBounds, isWithinThreshold)
-  }
-}
+module.exports = snapCheck

--- a/src/windows/window-snapper.js
+++ b/src/windows/window-snapper.js
@@ -13,27 +13,31 @@ let isCloseTo = (a, b, snapThreshold) => {
 
 module.exports = (windowBounds, screenBounds, snapThreshold) => {
   if (snapThreshold <= 0) {
-    return { x: windowBounds.x, y: windowBounds.y }
+    return { x: windowBounds.x, y: windowBounds.y, shouldSnap: false }
   }
 
   let windowEdges = getEdges(windowBounds)
   let screenEdges = getEdges(screenBounds)
-  let snapTo = { x: windowBounds.x, y: windowBounds.y }
+  let snapTo = { x: windowBounds.x, y: windowBounds.y, shouldSnap: false }
 
   if (isCloseTo(windowEdges.left, screenEdges.left, snapThreshold)) {
     snapTo.x = screenEdges.left
+    snapTo.shouldSnap = true
   }
 
   if (isCloseTo(windowEdges.right, screenEdges.right, snapThreshold)) {
     snapTo.x = screenEdges.right - windowBounds.width
+    snapTo.shouldSnap = true
   }
 
   if (isCloseTo(windowEdges.top, screenEdges.top, snapThreshold)) {
     snapTo.y = screenEdges.top
+    snapTo.shouldSnap = true
   }
 
   if (isCloseTo(windowEdges.bottom, screenEdges.bottom, snapThreshold)) {
     snapTo.y = screenEdges.bottom - windowBounds.height
+    snapTo.shouldSnap = true
   }
 
   return snapTo

--- a/src/windows/window-snapper.js
+++ b/src/windows/window-snapper.js
@@ -19,48 +19,34 @@ const setupThresholdCheck = snapThreshold => (a, b) => {
   return Math.abs(a - b) <= snapThreshold
 }
 
-const snapLeftCheck = (windowBounds, screenBounds, isWithinThreshold) => {
-  if (isWithinThreshold(windowBounds.x, screenBounds.x)) {
-    return {
-      x: screenBounds.x,
-      shouldSnap: true
-    }
-  }
-  return {}
-}
+const snapLeftCheck = (windowBounds, screenBounds, isWithinThreshold) =>
+  isWithinThreshold(windowBounds.x, screenBounds.x) ? {
+    x: screenBounds.x,
+    shouldSnap: true
+  } : undefined
 
 const snapRightCheck = (windowBounds, screenBounds, isWithinThreshold) => {
   const rightWindowEdge = windowBounds.x + windowBounds.width
   const rightScreenEdge = screenBounds.x + screenBounds.width
-  if (isWithinThreshold(rightWindowEdge, rightScreenEdge)) {
-    return {
-      x: rightScreenEdge - windowBounds.width,
-      shouldSnap: true
-    }
-  }
-  return {}
+  return isWithinThreshold(rightWindowEdge, rightScreenEdge) ? {
+    x: rightScreenEdge - windowBounds.width,
+    shouldSnap: true
+  } : undefined
 }
 
-const snapTopCheck = (windowBounds, screenBounds, isWithinThreshold) => {
-  if (isWithinThreshold(windowBounds.y, screenBounds.y)) {
-    return {
-      y: screenBounds.y,
-      shouldSnap: true
-    }
-  }
-  return {}
-}
+const snapTopCheck = (windowBounds, screenBounds, isWithinThreshold) =>
+  isWithinThreshold(windowBounds.y, screenBounds.y) ? {
+    y: screenBounds.y,
+    shouldSnap: true
+  } : undefined
 
 const snapBottomCheck = (windowBounds, screenBounds, isWithinThreshold) => {
   const bottomWindowEdge = windowBounds.y + windowBounds.height
   const bottomScreenEdge = screenBounds.y + screenBounds.height
-  if (isWithinThreshold(bottomWindowEdge, bottomScreenEdge)) {
-    return {
-      y: bottomScreenEdge - windowBounds.height,
-      shouldSnap: true
-    }
-  }
-  return {}
+  return isWithinThreshold(bottomWindowEdge, bottomScreenEdge) ? {
+    y: bottomScreenEdge - windowBounds.height,
+    shouldSnap: true
+  } : undefined
 }
 
 module.exports = snapCheck

--- a/src/windows/window-snapper.js
+++ b/src/windows/window-snapper.js
@@ -1,4 +1,4 @@
-let getEdges = bounds => {
+const getEdges = bounds => {
   return {
     top: bounds.y,
     bottom: bounds.y + bounds.height,
@@ -7,8 +7,48 @@ let getEdges = bounds => {
   }
 }
 
-let isCloseTo = (a, b, snapThreshold) => {
+const isCloseTo = (a, b, snapThreshold) => {
   return Math.abs(a - b) <= snapThreshold
+}
+
+const snapLeftCheck = (windowBounds, windowEdges, screenEdges, snapThreshold) => {
+  if (isCloseTo(windowEdges.left, screenEdges.left, snapThreshold)) {
+    return {
+      x: screenEdges.left,
+      shouldSnap: true
+    }
+  }
+  return {}
+}
+
+const snapRightCheck = (windowBounds, windowEdges, screenEdges, snapThreshold) => {
+  if (isCloseTo(windowEdges.right, screenEdges.right, snapThreshold)) {
+    return {
+      x: screenEdges.right - windowBounds.width,
+      shouldSnap: true
+    }
+  }
+  return {}
+}
+
+const snapTopCheck = (windowBounds, windowEdges, screenEdges, snapThreshold) => {
+  if (isCloseTo(windowEdges.top, screenEdges.top, snapThreshold)) {
+    return {
+      y: screenEdges.top,
+      shouldSnap: true
+    }
+  }
+  return {}
+}
+
+const snapBottomCheck = (windowBounds, windowEdges, screenEdges, snapThreshold) => {
+  if (isCloseTo(windowEdges.bottom, screenEdges.bottom, snapThreshold)) {
+    return {
+      y: screenEdges.bottom - windowBounds.height,
+      shouldSnap: true
+    }
+  }
+  return {}
 }
 
 module.exports = (windowBounds, screenBounds, snapThreshold) => {
@@ -16,29 +56,16 @@ module.exports = (windowBounds, screenBounds, snapThreshold) => {
     return { x: windowBounds.x, y: windowBounds.y, shouldSnap: false }
   }
 
-  let windowEdges = getEdges(windowBounds)
-  let screenEdges = getEdges(screenBounds)
-  let snapTo = { x: windowBounds.x, y: windowBounds.y, shouldSnap: false }
+  const windowEdges = getEdges(windowBounds)
+  const screenEdges = getEdges(screenBounds)
 
-  if (isCloseTo(windowEdges.left, screenEdges.left, snapThreshold)) {
-    snapTo.x = screenEdges.left
-    snapTo.shouldSnap = true
+  return {
+    x: windowBounds.x,
+    y: windowBounds.y,
+    shouldSnap: false,
+    ...snapLeftCheck(windowBounds, windowEdges, screenEdges, snapThreshold),
+    ...snapRightCheck(windowBounds, windowEdges, screenEdges, snapThreshold),
+    ...snapTopCheck(windowBounds, windowEdges, screenEdges, snapThreshold),
+    ...snapBottomCheck(windowBounds, windowEdges, screenEdges, snapThreshold)
   }
-
-  if (isCloseTo(windowEdges.right, screenEdges.right, snapThreshold)) {
-    snapTo.x = screenEdges.right - windowBounds.width
-    snapTo.shouldSnap = true
-  }
-
-  if (isCloseTo(windowEdges.top, screenEdges.top, snapThreshold)) {
-    snapTo.y = screenEdges.top
-    snapTo.shouldSnap = true
-  }
-
-  if (isCloseTo(windowEdges.bottom, screenEdges.bottom, snapThreshold)) {
-    snapTo.y = screenEdges.bottom - windowBounds.height
-    snapTo.shouldSnap = true
-  }
-
-  return snapTo
 }

--- a/src/windows/window-snapper.js
+++ b/src/windows/window-snapper.js
@@ -1,9 +1,9 @@
 const snapCheck = (windowBounds, screenBounds, snapThreshold) => {
-  const noSnap = { ...windowBounds, shouldSnap: false }
   if (snapThreshold <= 0) {
-    return noSnap
+    throw new Error('Not supported, not supposed to call window-snapper if threshold <= 0!')
   }
 
+  const noSnap = { ...windowBounds, shouldSnap: false }
   const isWithinThreshold = setupThresholdCheck(snapThreshold)
 
   return {

--- a/src/windows/window-snapper.js
+++ b/src/windows/window-snapper.js
@@ -1,50 +1,45 @@
-const getEdges = bounds => {
-  return {
-    top: bounds.y,
-    bottom: bounds.y + bounds.height,
-    left: bounds.x,
-    right: bounds.x + bounds.width
-  }
-}
-
 const isCloseTo = (a, b, snapThreshold) => {
   return Math.abs(a - b) <= snapThreshold
 }
 
-const snapLeftCheck = (windowBounds, windowEdges, screenEdges, snapThreshold) => {
-  if (isCloseTo(windowEdges.left, screenEdges.left, snapThreshold)) {
+const snapLeftCheck = (windowBounds, screenBounds, snapThreshold) => {
+  if (isCloseTo(windowBounds.x, screenBounds.x, snapThreshold)) {
     return {
-      x: screenEdges.left,
+      x: screenBounds.x,
       shouldSnap: true
     }
   }
   return {}
 }
 
-const snapRightCheck = (windowBounds, windowEdges, screenEdges, snapThreshold) => {
-  if (isCloseTo(windowEdges.right, screenEdges.right, snapThreshold)) {
+const snapRightCheck = (windowBounds, screenBounds, snapThreshold) => {
+  const rightWindowEdge = windowBounds.x + windowBounds.width
+  const rightScreenEdge = screenBounds.x + screenBounds.width
+  if (isCloseTo(rightWindowEdge, rightScreenEdge, snapThreshold)) {
     return {
-      x: screenEdges.right - windowBounds.width,
+      x: rightScreenEdge - windowBounds.width,
       shouldSnap: true
     }
   }
   return {}
 }
 
-const snapTopCheck = (windowBounds, windowEdges, screenEdges, snapThreshold) => {
-  if (isCloseTo(windowEdges.top, screenEdges.top, snapThreshold)) {
+const snapTopCheck = (windowBounds, screenBounds, snapThreshold) => {
+  if (isCloseTo(windowBounds.y, screenBounds.y, snapThreshold)) {
     return {
-      y: screenEdges.top,
+      y: screenBounds.y,
       shouldSnap: true
     }
   }
   return {}
 }
 
-const snapBottomCheck = (windowBounds, windowEdges, screenEdges, snapThreshold) => {
-  if (isCloseTo(windowEdges.bottom, screenEdges.bottom, snapThreshold)) {
+const snapBottomCheck = (windowBounds, screenBounds, snapThreshold) => {
+  const bottomWindowEdge = windowBounds.y + windowBounds.height
+  const bottomScreenEdge = screenBounds.y + screenBounds.height
+  if (isCloseTo(bottomWindowEdge, bottomScreenEdge, snapThreshold)) {
     return {
-      y: screenEdges.bottom - windowBounds.height,
+      y: bottomScreenEdge - windowBounds.height,
       shouldSnap: true
     }
   }
@@ -56,16 +51,13 @@ module.exports = (windowBounds, screenBounds, snapThreshold) => {
     return { x: windowBounds.x, y: windowBounds.y, shouldSnap: false }
   }
 
-  const windowEdges = getEdges(windowBounds)
-  const screenEdges = getEdges(screenBounds)
-
   return {
     x: windowBounds.x,
     y: windowBounds.y,
     shouldSnap: false,
-    ...snapLeftCheck(windowBounds, windowEdges, screenEdges, snapThreshold),
-    ...snapRightCheck(windowBounds, windowEdges, screenEdges, snapThreshold),
-    ...snapTopCheck(windowBounds, windowEdges, screenEdges, snapThreshold),
-    ...snapBottomCheck(windowBounds, windowEdges, screenEdges, snapThreshold)
+    ...snapLeftCheck(windowBounds, screenBounds, snapThreshold),
+    ...snapRightCheck(windowBounds, screenBounds, snapThreshold),
+    ...snapTopCheck(windowBounds, screenBounds, snapThreshold),
+    ...snapBottomCheck(windowBounds, screenBounds, snapThreshold)
   }
 }

--- a/src/windows/window-snapper.js
+++ b/src/windows/window-snapper.js
@@ -1,5 +1,5 @@
 const snapCheck = (windowBounds, screenBounds, snapThreshold) => {
-  const noSnap = { x: windowBounds.x, y: windowBounds.y, shouldSnap: false }
+  const noSnap = { ...windowBounds, shouldSnap: false }
   if (snapThreshold <= 0) {
     return noSnap
   }

--- a/src/windows/windows.js
+++ b/src/windows/windows.js
@@ -48,7 +48,7 @@ exports.createTimerWindow = () => {
     let screenBounds = electron.screen.getDisplayNearestPoint(getCenter(windowBounds)).workArea
 
     let snapTo = windowSnapper(windowBounds, screenBounds, snapThreshold)
-    if (snapTo.x !== windowBounds.x || snapTo.y !== windowBounds.y) {
+    if (snapTo.shouldSnap) {
       delayedSetBounds({
         width: timerWindowSize.width,
         height: timerWindowSize.height,

--- a/src/windows/windows.js
+++ b/src/windows/windows.js
@@ -1,6 +1,6 @@
 const electron = require('electron')
 const { app } = electron
-const windowSnapper = require('./window-snapper')
+const { snapCheck } = require('./window-snapper')
 const path = require('path')
 const { debounce } = require('debounce')
 
@@ -51,7 +51,7 @@ exports.createTimerWindow = () => {
     }
     let screenBounds = electron.screen.getDisplayNearestPoint(getCenter(windowBounds)).workArea
 
-    const { shouldSnap, ...snapBounds } = windowSnapper(windowBounds, screenBounds, snapThreshold)
+    const { shouldSnap, ...snapBounds } = snapCheck(windowBounds, screenBounds, snapThreshold)
     if (shouldSnap) {
       delayedSetBounds(snapBounds)
     } else {

--- a/src/windows/windows.js
+++ b/src/windows/windows.js
@@ -44,7 +44,11 @@ exports.createTimerWindow = () => {
       }
     }
 
-    let windowBounds = timerWindow.getBounds()
+    let windowBounds = {
+      ...timerWindow.getBounds(),
+      width: timerWindowSize.width,
+      height: timerWindowSize.height
+    }
     let screenBounds = electron.screen.getDisplayNearestPoint(getCenter(windowBounds)).workArea
 
     let snapTo = windowSnapper(windowBounds, screenBounds, snapThreshold)

--- a/src/windows/windows.js
+++ b/src/windows/windows.js
@@ -51,14 +51,9 @@ exports.createTimerWindow = () => {
     }
     let screenBounds = electron.screen.getDisplayNearestPoint(getCenter(windowBounds)).workArea
 
-    let snapTo = windowSnapper(windowBounds, screenBounds, snapThreshold)
-    if (snapTo.shouldSnap) {
-      delayedSetBounds({
-        width: timerWindowSize.width,
-        height: timerWindowSize.height,
-        x: snapTo.x,
-        y: snapTo.y
-      })
+    const { shouldSnap, ...snapBounds } = windowSnapper(windowBounds, screenBounds, snapThreshold)
+    if (shouldSnap) {
+      delayedSetBounds(snapBounds)
     } else {
       delayedSetBounds.clear()
     }

--- a/test/node-version.specs.js
+++ b/test/node-version.specs.js
@@ -1,11 +1,12 @@
 const fs = require('fs')
 const assert = require('assert')
 
-describe('Node version', () => {
-  it('.nvmrc should match .travis.yml', () => {
-    const nvmrc = fs.readFileSync('./.nvmrc', 'utf-8')
-    const travisYml = fs.readFileSync('./.travis.yml', 'utf-8')
+describe('Node versions', () => {
+  const nvmrc = fs.readFileSync('./.nvmrc', 'utf-8')
+  const travisYml = fs.readFileSync('./.travis.yml', 'utf-8')
+  const packageJson = fs.readFileSync('./package.json', 'utf-8')
 
+  it('.nvmrc should match .travis.yml', () => {
     const matches = travisYml.indexOf(`- "${nvmrc}"`) !== -1
     const message = [
       'Could not find node version from .nvmrc in .travis.yml!\n',
@@ -14,9 +15,9 @@ describe('Node version', () => {
   })
 
   it('.nvmrc should match package.json engines node version', () => {
-    const nvmrc = fs.readFileSync('./.nvmrc', 'utf-8')
-    const packageJson = JSON.parse(fs.readFileSync('./package.json', 'utf-8'))
-
-    assert.strictEqual(packageJson.engines.node, nvmrc)
+    const message = [
+      'Could not find node version from .nvmrc in package.json!\n',
+      '.nvmrc', nvmrc, 'package.json', packageJson]
+    assert.strictEqual(JSON.parse(packageJson).engines.node, nvmrc, message)
   })
 })

--- a/test/node-version.specs.js
+++ b/test/node-version.specs.js
@@ -12,4 +12,11 @@ describe('Node version', () => {
       '.nvmrc', nvmrc, '.travis.yml', travisYml]
     assert.ok(matches, message.join('\n'))
   })
+
+  it('.nvmrc should match package.json engines node version', () => {
+    const nvmrc = fs.readFileSync('./.nvmrc', 'utf-8')
+    const packageJson = JSON.parse(fs.readFileSync('./package.json', 'utf-8'))
+
+    assert.strictEqual(packageJson.engines.node, nvmrc)
+  })
 })

--- a/test/windows/window-snapper.specs.js
+++ b/test/windows/window-snapper.specs.js
@@ -2,11 +2,85 @@ const windowSnapper = require('../../src/windows/window-snapper')
 const assert = require('assert')
 
 describe('window-snapper', () => {
+  const fullHdScreen = { x: 0, y: 0, width: 1920, height: 1080 }
+
   it('should return window coordinates if threshold is 0', () => {
-    const windowBounds = { x: 0, y: 0, width: 1920, height: 1080 }
-    const screenBounds = {}
+    const windowBounds = { x: 13, y: 37, width: 220, height: 90 }
+    const screenBounds = fullHdScreen
     const snapThreshold = 0
     const result = windowSnapper(windowBounds, screenBounds, snapThreshold)
+    assert.deepStrictEqual(result, { x: 13, y: 37 })
+  })
+
+  it('should not snap if far from edges', () => {
+    const windowBounds = { x: 11, y: 11, width: 200 - 11 - 11, height: 200 - 11 - 11 }
+    const screenBounds = { x: 0, y: 0, width: 200, height: 200 }
+    const snapThreshold = 10
+    const result = windowSnapper(windowBounds, screenBounds, snapThreshold)
+    assert.deepStrictEqual(result, { x: 11, y: 11 })
+  })
+
+  it('should snap to the left if close to the left screen edge', () => {
+    const windowBounds = { x: 9, y: 11, width: 220, height: 90 }
+    const screenBounds = fullHdScreen
+    const snapThreshold = 10
+    const result = windowSnapper(windowBounds, screenBounds, snapThreshold)
+    assert.deepStrictEqual(result, { x: 0, y: 11 })
+  })
+
+  it('should snap to the top and left if close to the top left screen corner', () => {
+    const windowBounds = { x: 5, y: 8, width: 220, height: 90 }
+    const screenBounds = fullHdScreen
+    const snapThreshold = 10
+    const result = windowSnapper(windowBounds, screenBounds, snapThreshold)
     assert.deepStrictEqual(result, { x: 0, y: 0 })
+  })
+
+  it('should snap to the top if close to the top screen edge', () => {
+    const windowBounds = { x: 14, y: 8, width: 220, height: 90 }
+    const screenBounds = fullHdScreen
+    const snapThreshold = 10
+    const result = windowSnapper(windowBounds, screenBounds, snapThreshold)
+    assert.deepStrictEqual(result, { x: 14, y: 0 })
+  })
+
+  it('should snap to the top and right if close to the top right screen corner', () => {
+    const windowBounds = { x: 1708, y: 2, width: 220, height: 90 }
+    const screenBounds = fullHdScreen
+    const snapThreshold = 10
+    const result = windowSnapper(windowBounds, screenBounds, snapThreshold)
+    assert.deepStrictEqual(result, { x: 1700, y: 0 })
+  })
+
+  it('should snap to the right if close to the right screen edge', () => {
+    const windowBounds = { x: 1708, y: 13, width: 220, height: 90 }
+    const screenBounds = fullHdScreen
+    const snapThreshold = 10
+    const result = windowSnapper(windowBounds, screenBounds, snapThreshold)
+    assert.deepStrictEqual(result, { x: 1700, y: 13 })
+  })
+
+  it('should snap to the right and bottom if close to the right bottom screen corner', () => {
+    const windowBounds = { x: 1708, y: 995, width: 220, height: 90 }
+    const screenBounds = fullHdScreen
+    const snapThreshold = 10
+    const result = windowSnapper(windowBounds, screenBounds, snapThreshold)
+    assert.deepStrictEqual(result, { x: 1700, y: 990 })
+  })
+
+  it('should snap to the bottom if close to the bottom screen edge', () => {
+    const windowBounds = { x: 1685, y: 985, width: 220, height: 90 }
+    const screenBounds = fullHdScreen
+    const snapThreshold = 10
+    const result = windowSnapper(windowBounds, screenBounds, snapThreshold)
+    assert.deepStrictEqual(result, { x: 1685, y: 990 })
+  })
+
+  it('should snap to the bottom and left if close to the bottom left screen corner', () => {
+    const windowBounds = { x: 9, y: 985, width: 220, height: 90 }
+    const screenBounds = fullHdScreen
+    const snapThreshold = 10
+    const result = windowSnapper(windowBounds, screenBounds, snapThreshold)
+    assert.deepStrictEqual(result, { x: 0, y: 990 })
   })
 })

--- a/test/windows/window-snapper.specs.js
+++ b/test/windows/window-snapper.specs.js
@@ -9,7 +9,7 @@ describe('window-snapper', () => {
     const screenBounds = fullHdScreen
     const snapThreshold = 0
     const result = windowSnapper(windowBounds, screenBounds, snapThreshold)
-    assert.deepStrictEqual(result, { x: 13, y: 37 })
+    assert.deepStrictEqual(result, { x: 13, y: 37, shouldSnap: false })
   })
 
   it('should not snap if far from edges', () => {
@@ -17,7 +17,7 @@ describe('window-snapper', () => {
     const screenBounds = { x: 0, y: 0, width: 200, height: 200 }
     const snapThreshold = 10
     const result = windowSnapper(windowBounds, screenBounds, snapThreshold)
-    assert.deepStrictEqual(result, { x: 11, y: 11 })
+    assert.deepStrictEqual(result, { x: 11, y: 11, shouldSnap: false })
   })
 
   it('should snap to the left if close to the left screen edge', () => {
@@ -25,7 +25,7 @@ describe('window-snapper', () => {
     const screenBounds = fullHdScreen
     const snapThreshold = 10
     const result = windowSnapper(windowBounds, screenBounds, snapThreshold)
-    assert.deepStrictEqual(result, { x: 0, y: 11 })
+    assert.deepStrictEqual(result, { x: 0, y: 11, shouldSnap: true })
   })
 
   it('should snap to the top and left if close to the top left screen corner', () => {
@@ -33,7 +33,7 @@ describe('window-snapper', () => {
     const screenBounds = fullHdScreen
     const snapThreshold = 10
     const result = windowSnapper(windowBounds, screenBounds, snapThreshold)
-    assert.deepStrictEqual(result, { x: 0, y: 0 })
+    assert.deepStrictEqual(result, { x: 0, y: 0, shouldSnap: true })
   })
 
   it('should snap to the top if close to the top screen edge', () => {
@@ -41,7 +41,7 @@ describe('window-snapper', () => {
     const screenBounds = fullHdScreen
     const snapThreshold = 10
     const result = windowSnapper(windowBounds, screenBounds, snapThreshold)
-    assert.deepStrictEqual(result, { x: 14, y: 0 })
+    assert.deepStrictEqual(result, { x: 14, y: 0, shouldSnap: true })
   })
 
   it('should snap to the top and right if close to the top right screen corner', () => {
@@ -49,7 +49,7 @@ describe('window-snapper', () => {
     const screenBounds = fullHdScreen
     const snapThreshold = 10
     const result = windowSnapper(windowBounds, screenBounds, snapThreshold)
-    assert.deepStrictEqual(result, { x: 1700, y: 0 })
+    assert.deepStrictEqual(result, { x: 1700, y: 0, shouldSnap: true })
   })
 
   it('should snap to the right if close to the right screen edge', () => {
@@ -57,7 +57,7 @@ describe('window-snapper', () => {
     const screenBounds = fullHdScreen
     const snapThreshold = 10
     const result = windowSnapper(windowBounds, screenBounds, snapThreshold)
-    assert.deepStrictEqual(result, { x: 1700, y: 13 })
+    assert.deepStrictEqual(result, { x: 1700, y: 13, shouldSnap: true })
   })
 
   it('should snap to the right and bottom if close to the right bottom screen corner', () => {
@@ -65,7 +65,7 @@ describe('window-snapper', () => {
     const screenBounds = fullHdScreen
     const snapThreshold = 10
     const result = windowSnapper(windowBounds, screenBounds, snapThreshold)
-    assert.deepStrictEqual(result, { x: 1700, y: 990 })
+    assert.deepStrictEqual(result, { x: 1700, y: 990, shouldSnap: true })
   })
 
   it('should snap to the bottom if close to the bottom screen edge', () => {
@@ -73,7 +73,7 @@ describe('window-snapper', () => {
     const screenBounds = fullHdScreen
     const snapThreshold = 10
     const result = windowSnapper(windowBounds, screenBounds, snapThreshold)
-    assert.deepStrictEqual(result, { x: 1685, y: 990 })
+    assert.deepStrictEqual(result, { x: 1685, y: 990, shouldSnap: true })
   })
 
   it('should snap to the bottom and left if close to the bottom left screen corner', () => {
@@ -81,6 +81,6 @@ describe('window-snapper', () => {
     const screenBounds = fullHdScreen
     const snapThreshold = 10
     const result = windowSnapper(windowBounds, screenBounds, snapThreshold)
-    assert.deepStrictEqual(result, { x: 0, y: 990 })
+    assert.deepStrictEqual(result, { x: 0, y: 990, shouldSnap: true })
   })
 })

--- a/test/windows/window-snapper.specs.js
+++ b/test/windows/window-snapper.specs.js
@@ -1,14 +1,14 @@
-const windowSnapper = require('../../src/windows/window-snapper')
+const { snapCheck } = require('../../src/windows/window-snapper')
 const assert = require('assert')
 
-describe('window-snapper', () => {
+describe('window-snapper snapCheck', () => {
   const fullHdScreen = { x: 0, y: 0, width: 1920, height: 1080 }
 
   it('should throw if threshold is 0 since it should not even be called', () => {
     const windowBounds = { x: 13, y: 37, width: 220, height: 90 }
     const screenBounds = fullHdScreen
     const snapThreshold = 0
-    const act = () => windowSnapper(windowBounds, screenBounds, snapThreshold)
+    const act = () => snapCheck(windowBounds, screenBounds, snapThreshold)
     assert.throws(act)
   })
 
@@ -16,7 +16,7 @@ describe('window-snapper', () => {
     const windowBounds = { x: 11, y: 11, width: 200 - 11 - 11, height: 200 - 11 - 11 }
     const screenBounds = { x: 0, y: 0, width: 200, height: 200 }
     const snapThreshold = 10
-    const result = windowSnapper(windowBounds, screenBounds, snapThreshold)
+    const result = snapCheck(windowBounds, screenBounds, snapThreshold)
     assert.deepStrictEqual(result, {
       x: 11,
       y: 11,
@@ -30,7 +30,7 @@ describe('window-snapper', () => {
     const windowBounds = { x: 9, y: 11, width: 220, height: 90 }
     const screenBounds = fullHdScreen
     const snapThreshold = 10
-    const result = windowSnapper(windowBounds, screenBounds, snapThreshold)
+    const result = snapCheck(windowBounds, screenBounds, snapThreshold)
     assert.deepStrictEqual(result, {
       x: 0,
       y: 11,
@@ -44,7 +44,7 @@ describe('window-snapper', () => {
     const windowBounds = { x: 5, y: 8, width: 220, height: 90 }
     const screenBounds = fullHdScreen
     const snapThreshold = 10
-    const result = windowSnapper(windowBounds, screenBounds, snapThreshold)
+    const result = snapCheck(windowBounds, screenBounds, snapThreshold)
     assert.deepStrictEqual(result, {
       x: 0,
       y: 0,
@@ -58,7 +58,7 @@ describe('window-snapper', () => {
     const windowBounds = { x: 14, y: 8, width: 220, height: 90 }
     const screenBounds = fullHdScreen
     const snapThreshold = 10
-    const result = windowSnapper(windowBounds, screenBounds, snapThreshold)
+    const result = snapCheck(windowBounds, screenBounds, snapThreshold)
     assert.deepStrictEqual(result, {
       x: 14,
       y: 0,
@@ -72,7 +72,7 @@ describe('window-snapper', () => {
     const windowBounds = { x: 1708, y: 2, width: 220, height: 90 }
     const screenBounds = fullHdScreen
     const snapThreshold = 10
-    const result = windowSnapper(windowBounds, screenBounds, snapThreshold)
+    const result = snapCheck(windowBounds, screenBounds, snapThreshold)
     assert.deepStrictEqual(result, {
       x: 1700,
       y: 0,
@@ -86,7 +86,7 @@ describe('window-snapper', () => {
     const windowBounds = { x: 1708, y: 13, width: 220, height: 90 }
     const screenBounds = fullHdScreen
     const snapThreshold = 10
-    const result = windowSnapper(windowBounds, screenBounds, snapThreshold)
+    const result = snapCheck(windowBounds, screenBounds, snapThreshold)
     assert.deepStrictEqual(result, {
       x: 1700,
       y: 13,
@@ -100,7 +100,7 @@ describe('window-snapper', () => {
     const windowBounds = { x: 1708, y: 995, width: 220, height: 90 }
     const screenBounds = fullHdScreen
     const snapThreshold = 10
-    const result = windowSnapper(windowBounds, screenBounds, snapThreshold)
+    const result = snapCheck(windowBounds, screenBounds, snapThreshold)
     assert.deepStrictEqual(result, {
       x: 1700,
       y: 990,
@@ -114,7 +114,7 @@ describe('window-snapper', () => {
     const windowBounds = { x: 1685, y: 985, width: 220, height: 90 }
     const screenBounds = fullHdScreen
     const snapThreshold = 10
-    const result = windowSnapper(windowBounds, screenBounds, snapThreshold)
+    const result = snapCheck(windowBounds, screenBounds, snapThreshold)
     assert.deepStrictEqual(result, {
       x: 1685,
       y: 990,
@@ -128,7 +128,7 @@ describe('window-snapper', () => {
     const windowBounds = { x: 9, y: 985, width: 220, height: 90 }
     const screenBounds = fullHdScreen
     const snapThreshold = 10
-    const result = windowSnapper(windowBounds, screenBounds, snapThreshold)
+    const result = snapCheck(windowBounds, screenBounds, snapThreshold)
     assert.deepStrictEqual(result, {
       x: 0,
       y: 990,

--- a/test/windows/window-snapper.specs.js
+++ b/test/windows/window-snapper.specs.js
@@ -9,7 +9,13 @@ describe('window-snapper', () => {
     const screenBounds = fullHdScreen
     const snapThreshold = 0
     const result = windowSnapper(windowBounds, screenBounds, snapThreshold)
-    assert.deepStrictEqual(result, { x: 13, y: 37, shouldSnap: false })
+    assert.deepStrictEqual(result, {
+      x: 13,
+      y: 37,
+      width: 220,
+      height: 90,
+      shouldSnap: false
+    })
   })
 
   it('should not snap if far from edges', () => {
@@ -17,7 +23,13 @@ describe('window-snapper', () => {
     const screenBounds = { x: 0, y: 0, width: 200, height: 200 }
     const snapThreshold = 10
     const result = windowSnapper(windowBounds, screenBounds, snapThreshold)
-    assert.deepStrictEqual(result, { x: 11, y: 11, shouldSnap: false })
+    assert.deepStrictEqual(result, {
+      x: 11,
+      y: 11,
+      width: 178,
+      height: 178,
+      shouldSnap: false
+    })
   })
 
   it('should snap to the left if close to the left screen edge', () => {
@@ -25,7 +37,13 @@ describe('window-snapper', () => {
     const screenBounds = fullHdScreen
     const snapThreshold = 10
     const result = windowSnapper(windowBounds, screenBounds, snapThreshold)
-    assert.deepStrictEqual(result, { x: 0, y: 11, shouldSnap: true })
+    assert.deepStrictEqual(result, {
+      x: 0,
+      y: 11,
+      width: 220,
+      height: 90,
+      shouldSnap: true
+    })
   })
 
   it('should snap to the top and left if close to the top left screen corner', () => {
@@ -33,7 +51,13 @@ describe('window-snapper', () => {
     const screenBounds = fullHdScreen
     const snapThreshold = 10
     const result = windowSnapper(windowBounds, screenBounds, snapThreshold)
-    assert.deepStrictEqual(result, { x: 0, y: 0, shouldSnap: true })
+    assert.deepStrictEqual(result, {
+      x: 0,
+      y: 0,
+      width: 220,
+      height: 90,
+      shouldSnap: true
+    })
   })
 
   it('should snap to the top if close to the top screen edge', () => {
@@ -41,7 +65,13 @@ describe('window-snapper', () => {
     const screenBounds = fullHdScreen
     const snapThreshold = 10
     const result = windowSnapper(windowBounds, screenBounds, snapThreshold)
-    assert.deepStrictEqual(result, { x: 14, y: 0, shouldSnap: true })
+    assert.deepStrictEqual(result, {
+      x: 14,
+      y: 0,
+      width: 220,
+      height: 90,
+      shouldSnap: true
+    })
   })
 
   it('should snap to the top and right if close to the top right screen corner', () => {
@@ -49,7 +79,13 @@ describe('window-snapper', () => {
     const screenBounds = fullHdScreen
     const snapThreshold = 10
     const result = windowSnapper(windowBounds, screenBounds, snapThreshold)
-    assert.deepStrictEqual(result, { x: 1700, y: 0, shouldSnap: true })
+    assert.deepStrictEqual(result, {
+      x: 1700,
+      y: 0,
+      width: 220,
+      height: 90,
+      shouldSnap: true
+    })
   })
 
   it('should snap to the right if close to the right screen edge', () => {
@@ -57,7 +93,13 @@ describe('window-snapper', () => {
     const screenBounds = fullHdScreen
     const snapThreshold = 10
     const result = windowSnapper(windowBounds, screenBounds, snapThreshold)
-    assert.deepStrictEqual(result, { x: 1700, y: 13, shouldSnap: true })
+    assert.deepStrictEqual(result, {
+      x: 1700,
+      y: 13,
+      width: 220,
+      height: 90,
+      shouldSnap: true
+    })
   })
 
   it('should snap to the right and bottom if close to the right bottom screen corner', () => {
@@ -65,7 +107,13 @@ describe('window-snapper', () => {
     const screenBounds = fullHdScreen
     const snapThreshold = 10
     const result = windowSnapper(windowBounds, screenBounds, snapThreshold)
-    assert.deepStrictEqual(result, { x: 1700, y: 990, shouldSnap: true })
+    assert.deepStrictEqual(result, {
+      x: 1700,
+      y: 990,
+      width: 220,
+      height: 90,
+      shouldSnap: true
+    })
   })
 
   it('should snap to the bottom if close to the bottom screen edge', () => {
@@ -73,7 +121,13 @@ describe('window-snapper', () => {
     const screenBounds = fullHdScreen
     const snapThreshold = 10
     const result = windowSnapper(windowBounds, screenBounds, snapThreshold)
-    assert.deepStrictEqual(result, { x: 1685, y: 990, shouldSnap: true })
+    assert.deepStrictEqual(result, {
+      x: 1685,
+      y: 990,
+      width: 220,
+      height: 90,
+      shouldSnap: true
+    })
   })
 
   it('should snap to the bottom and left if close to the bottom left screen corner', () => {
@@ -81,6 +135,12 @@ describe('window-snapper', () => {
     const screenBounds = fullHdScreen
     const snapThreshold = 10
     const result = windowSnapper(windowBounds, screenBounds, snapThreshold)
-    assert.deepStrictEqual(result, { x: 0, y: 990, shouldSnap: true })
+    assert.deepStrictEqual(result, {
+      x: 0,
+      y: 990,
+      width: 220,
+      height: 90,
+      shouldSnap: true
+    })
   })
 })

--- a/test/windows/window-snapper.specs.js
+++ b/test/windows/window-snapper.specs.js
@@ -4,18 +4,12 @@ const assert = require('assert')
 describe('window-snapper', () => {
   const fullHdScreen = { x: 0, y: 0, width: 1920, height: 1080 }
 
-  it('should return window coordinates if threshold is 0', () => {
+  it('should throw if threshold is 0 since it should not even be called', () => {
     const windowBounds = { x: 13, y: 37, width: 220, height: 90 }
     const screenBounds = fullHdScreen
     const snapThreshold = 0
-    const result = windowSnapper(windowBounds, screenBounds, snapThreshold)
-    assert.deepStrictEqual(result, {
-      x: 13,
-      y: 37,
-      width: 220,
-      height: 90,
-      shouldSnap: false
-    })
+    const act = () => windowSnapper(windowBounds, screenBounds, snapThreshold)
+    assert.throws(act)
   })
 
   it('should not snap if far from edges', () => {


### PR DESCRIPTION
As a developer
In order to have a more readable and robust code
I want to know if I should snap window without comparing pixel values

As a developer
In order to have a more readable and robust code
I want window-snapper to be implemented without mutating properties or re-assigning variables