### PR TITLE
Solve 🐔 and 🥚 problem with electron node

### DIFF
--- a/test/node-version.specs.js
+++ b/test/node-version.specs.js
@@ -5,35 +5,38 @@ const packageJson = require('../package.json')
 const packageLockJson = require('../package-lock.json')
 
 describe('Node versions', () => {
-  const nodeVersionUsedByElectron = getNodeVersionUsedByElectron()
+  const { electronVersion, nodeVersion } = getMatchingElectronReleaseInfo()
 
-  it(`should find node version used by electron`, () => {
-    assert.ok(nodeVersionUsedByElectron.length, `Found: ${nodeVersionUsedByElectron}`)
+  it(`should find node version used by electron (${electronVersion})`, () => {
+    assert.ok(nodeVersion.length, `Found: ${nodeVersion}`)
   })
 
-  it(`should find node version ${nodeVersionUsedByElectron} in .nvmrc`, () => {
+  it(`should find node version ${nodeVersion} in .nvmrc`, () => {
     const nvmrc = fs.readFileSync('./.nvmrc', 'utf-8')
-    assert.strictEqual(nvmrc, nodeVersionUsedByElectron)
+    assert.strictEqual(nvmrc, nodeVersion)
   })
 
-  it(`should find node version ${nodeVersionUsedByElectron} in .travis.yml`, () => {
+  it(`should find node version ${nodeVersion} in .travis.yml`, () => {
     const travisYml = fs.readFileSync('./.travis.yml', 'utf-8')
-    const matches = travisYml.indexOf(`- "${nodeVersionUsedByElectron}"`) !== -1
+    const matches = travisYml.indexOf(`- "${nodeVersion}"`) !== -1
     const failMessage = [
-      `Could not find node version ${nodeVersionUsedByElectron} in .travis.yml!`,
+      `Could not find node version ${nodeVersion} in .travis.yml!`,
       travisYml
     ]
     assert.ok(matches, failMessage.join('\n'))
   })
 
-  it(`should find engines node version ${nodeVersionUsedByElectron} in package.json`, () => {
-    assert.strictEqual(packageJson.engines.node, nodeVersionUsedByElectron)
+  it(`should find engines node version ${nodeVersion} in package.json`, () => {
+    assert.strictEqual(packageJson.engines.node, nodeVersion)
   })
 })
 
-function getNodeVersionUsedByElectron() {
+function getMatchingElectronReleaseInfo() {
   const electronVersion = packageLockJson.dependencies.electron.version
-  const electronRelease = electronReleases.find(release =>
+  const exactMatchElectronRelease = electronReleases.find(release =>
     release.version === electronVersion)
-  return electronRelease.deps.node
+  const majorVersionElectronRelease = electronReleases.find(release =>
+    release.version[ 0 ] === electronVersion[ 0 ])
+  const foundRelease = exactMatchElectronRelease || majorVersionElectronRelease
+  return { electronVersion: foundRelease.version, nodeVersion: foundRelease.deps.node }
 }


### PR DESCRIPTION
# Why?

As a developer
In order to not get greenkeeper issues as soon as electron releases a new npm package version (like #25)
I want the node version check to be more stable

# What?

Fall back to major version match.
With this there can be an unknowing mismatch in node.js minor version number for a short time.
If electron releases a major upgrade then the node.js version has changed and checks will fail regardless.

[`electron`](https://github.com/electron/electron) - Build cross-platform desktop apps with JavaScript, HTML, and CSS
[`electron-releases`](https://github.com/electron/releases) -  Complete and up-to-date info about every release of Electron

Scenario A:
- New release of the `electron` npm package (with updated node.js), and greenkeeper upgrades
- Match not found in not upgraded metadata `electron-releases` npm package
- Fallback to Major version match
- Tests pass and PR is opened
- Developer knows about the metadata `electron-releases` npm package, upgrades package and adjusts node.js versions
- Developer merges PR
- Done

Scenario B:
- New release of the `electron` npm package (with updated node.js), and greenkeeper upgrades
- Match not found in not upgraded metadata `electron-releases` npm package
- Fallback to Major version match
- Tests pass and PR is opened
- Developer merges PR
- Greenkeeper upgrades the metadata `electron-releases` npm package, opens issue about breaking tests
- Developer adjusts node.js versions
- Developer merges PR
- Done