### PR TITLE
Warn if prettier format not followed

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -16,10 +16,8 @@
     "document": "readonly"
   },
   "plugins": [
-    "node",
     "promise",
-    "mocha",
-    "import"
+    "mocha"
   ],
   "rules": {
     "node/no-unpublished-require": [

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -29,6 +29,7 @@
           "electron"
         ]
       }
-    ]
+    ],
+    "prettier/prettier": "warn"
   }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,7 +4,8 @@
     "plugin:node/recommended",
     "plugin:promise/recommended",
     "plugin:mocha/recommended",
-    "plugin:import/recommended"
+    "plugin:import/recommended",
+    "plugin:prettier/recommended"
   ],
   "env": {
     "node": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1542,12 +1542,6 @@
         }
       }
     },
-    "eslint-config-standard": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-12.0.0.tgz",
-      "integrity": "sha512-COUz8FnXhqFitYj4DTqHzidjIL/t4mumGZto5c7DrBpvWoie+Sn3P4sLEzUGeYhRElWuFEf8K1S1EfvD1vixCQ==",
-      "dev": true
-    },
     "eslint-import-resolver-node": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.2.tgz",
@@ -2572,7 +2566,8 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/imul/-/imul-1.0.1.tgz",
       "integrity": "sha1-nVhnFh6LPelsLDjV3HyxAvNeKsk=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "imurmurhash": {
       "version": "0.1.4",
@@ -2865,7 +2860,8 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
       "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "is-regex": {
       "version": "1.0.4",
@@ -3470,7 +3466,8 @@
       "version": "2.11.1",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.1.tgz",
       "integrity": "sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "nanomatch": {
       "version": "1.2.13",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1542,6 +1542,23 @@
         }
       }
     },
+    "eslint-config-prettier": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-4.1.0.tgz",
+      "integrity": "sha512-zILwX9/Ocz4SV2vX7ox85AsrAgXV3f2o2gpIicdMIOra48WYqgUnWNH/cR/iHtmD2Vb3dLSC3LiEJnS05Gkw7w==",
+      "dev": true,
+      "requires": {
+        "get-stdin": "^6.0.0"
+      },
+      "dependencies": {
+        "get-stdin": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
+          "integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==",
+          "dev": true
+        }
+      }
+    },
     "eslint-import-resolver-node": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.2.tgz",
@@ -1703,6 +1720,15 @@
           "integrity": "sha512-WLsTMEhsQuXpCiG173+f3aymI43SXa+fB1rSfbzyP4GkPP+ZFVuO0/3sFUGNBtifisPeDcl/uD/Y2NxZ7xFq4g==",
           "dev": true
         }
+      }
+    },
+    "eslint-plugin-prettier": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.0.1.tgz",
+      "integrity": "sha512-/PMttrarPAY78PLvV3xfWibMOdMDl57hmlQ2XqFeA37wd+CJ7WSxV7txqjVPHi/AAFKd2lX0ZqfsOc/i5yFCSQ==",
+      "dev": true,
+      "requires": {
+        "prettier-linter-helpers": "^1.0.0"
       }
     },
     "eslint-plugin-promise": {
@@ -1984,6 +2010,12 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
       "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+      "dev": true
+    },
+    "fast-diff": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
+      "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
       "dev": true
     },
     "fast-json-stable-stringify": {
@@ -2566,8 +2598,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/imul/-/imul-1.0.1.tgz",
       "integrity": "sha1-nVhnFh6LPelsLDjV3HyxAvNeKsk=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "imurmurhash": {
       "version": "0.1.4",
@@ -2860,8 +2891,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
       "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "is-regex": {
       "version": "1.0.4",
@@ -3466,8 +3496,7 @@
       "version": "2.11.1",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.1.tgz",
       "integrity": "sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -5041,6 +5070,21 @@
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
       "dev": true
+    },
+    "prettier": {
+      "version": "1.16.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.16.4.tgz",
+      "integrity": "sha512-ZzWuos7TI5CKUeQAtFd6Zhm2s6EpAD/ZLApIhsF9pRvRtM1RFo61dM/4MSRUA0SuLugA/zgrZD8m0BaY46Og7g==",
+      "dev": true
+    },
+    "prettier-linter-helpers": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
+      "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
+      "dev": true,
+      "requires": {
+        "fast-diff": "^1.1.2"
+      }
     },
     "pretty-bytes": {
       "version": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -47,12 +47,15 @@
     "electron-packager": "^13.0.1",
     "electron-releases": "^3.86.0",
     "eslint": "^5.8.0",
+    "eslint-config-prettier": "^4.1.0",
     "eslint-plugin-import": "^2.16.0",
     "eslint-plugin-mocha": "^5.2.0",
     "eslint-plugin-node": "^8.0.0",
+    "eslint-plugin-prettier": "^3.0.1",
     "eslint-plugin-promise": "^4.0.1",
     "mocha": "^6.0.0",
     "nyc": "^13.3.0",
+    "prettier": "^1.16.4",
     "sinon": "^7.1.1"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "electron-packager": "^13.0.1",
     "electron-releases": "^3.86.0",
     "eslint": "^5.8.0",
-    "eslint-config-standard": "^12.0.0",
     "eslint-plugin-import": "^2.16.0",
     "eslint-plugin-mocha": "^5.2.0",
     "eslint-plugin-node": "^8.0.0",


### PR DESCRIPTION
As a developer
In order to get fewer merge conflicts, more consistent code and a feeling of familiarity
I want the code to be formatted by `prettier`

As a developer
In order to know how `prettier` was set up
I want prettier to be set up separately from the formatting of the code base (`prettier/prettier: warn` for now)

See #20 for more details.

# What?

- Add `prettier` and warn with `eslint` if `prettier` is not followed.

Bonus:
- Remove unused `eslint-config-standard`
- Remove redundant additions to `.eslintrc.json` plugins section