### PR TITLE
Increase config window size

### DIFF
--- a/src/windows/config/initialize.js
+++ b/src/windows/config/initialize.js
@@ -1,6 +1,21 @@
 const electron = require("electron");
 
-exports.createConfigWindow = () => {
+let configWindow;
+
+exports.showConfigWindow = () => {
+  if (configWindow) {
+    configWindow.showWindow();
+    return;
+  }
+  configWindow = createConfigWindow();
+  configWindow.onClose(() => (configWindow = null));
+};
+
+exports.sendEventToConfigWindow = (event, data) => {
+  configWindow && configWindow.sendEvent(event, data);
+};
+
+const createConfigWindow = () => {
   const configWindowInstance = new electron.BrowserWindow({
     width: 420,
     height: 500,

--- a/src/windows/config/initialize.js
+++ b/src/windows/config/initialize.js
@@ -18,7 +18,7 @@ exports.sendEventToConfigWindow = (event, data) => {
 const createConfigWindow = () => {
   const configWindowInstance = new electron.BrowserWindow({
     width: 420,
-    height: 500,
+    height: 650,
     autoHideMenuBar: true,
     webPreferences: {
       nodeIntegration: true

--- a/src/windows/config/initialize.js
+++ b/src/windows/config/initialize.js
@@ -14,6 +14,7 @@ exports.createConfigWindow = () => {
 
   return {
     instance: configWindowInstance,
-    showWindow: () => configWindowInstance.show()
+    showWindow: () => configWindowInstance.show(),
+    onClose: callback => configWindowInstance.on("closed", callback)
   };
 };

--- a/src/windows/config/initialize.js
+++ b/src/windows/config/initialize.js
@@ -1,0 +1,18 @@
+const electron = require("electron");
+
+exports.createConfigWindow = () => {
+  const configWindowInstance = new electron.BrowserWindow({
+    width: 420,
+    height: 500,
+    autoHideMenuBar: true,
+    webPreferences: {
+      nodeIntegration: true
+    }
+  });
+
+  configWindowInstance.loadURL(`file://${__dirname}/index.html`);
+
+  return {
+    instance: configWindowInstance
+  };
+};

--- a/src/windows/config/initialize.js
+++ b/src/windows/config/initialize.js
@@ -13,6 +13,7 @@ exports.createConfigWindow = () => {
   configWindowInstance.loadURL(`file://${__dirname}/index.html`);
 
   return {
-    instance: configWindowInstance
+    instance: configWindowInstance,
+    showWindow: () => configWindowInstance.show()
   };
 };

--- a/src/windows/config/initialize.js
+++ b/src/windows/config/initialize.js
@@ -13,8 +13,9 @@ exports.createConfigWindow = () => {
   configWindowInstance.loadURL(`file://${__dirname}/index.html`);
 
   return {
-    instance: configWindowInstance,
     showWindow: () => configWindowInstance.show(),
-    onClose: callback => configWindowInstance.on("closed", callback)
+    onClose: callback => configWindowInstance.on("closed", callback),
+    sendEvent: (event, data) =>
+      configWindowInstance.webContents.send(event, data)
   };
 };

--- a/src/windows/config/initialize.js
+++ b/src/windows/config/initialize.js
@@ -1,4 +1,4 @@
-const electron = require("electron");
+const { BrowserWindow } = require("electron");
 
 let configWindow;
 
@@ -16,7 +16,7 @@ exports.sendEventToConfigWindow = (event, data) => {
 };
 
 const createConfigWindow = () => {
-  const configWindowInstance = new electron.BrowserWindow({
+  const configWindowInstance = new BrowserWindow({
     width: 420,
     height: 650,
     autoHideMenuBar: true,

--- a/src/windows/windows.js
+++ b/src/windows/windows.js
@@ -75,14 +75,6 @@ exports.showConfigWindow = () => {
     configWindow.showWindow();
     return;
   }
-  exports.createConfigWindow();
-};
-
-exports.createConfigWindow = () => {
-  if (configWindow) {
-    return;
-  }
-
   configWindow = createConfigWindow();
   configWindow.onClose(() => (configWindow = null));
 };

--- a/src/windows/windows.js
+++ b/src/windows/windows.js
@@ -72,7 +72,7 @@ exports.createTimerWindow = () => {
 
 exports.showConfigWindow = () => {
   if (configWindow) {
-    configWindow.instance.show();
+    configWindow.showWindow();
     return;
   }
   exports.createConfigWindow();

--- a/src/windows/windows.js
+++ b/src/windows/windows.js
@@ -84,7 +84,7 @@ exports.createConfigWindow = () => {
   }
 
   configWindow = createConfigWindow();
-  configWindow.instance.on("closed", () => (configWindow = null));
+  configWindow.onClose(() => (configWindow = null));
 };
 
 exports.createFullscreenWindow = () => {

--- a/src/windows/windows.js
+++ b/src/windows/windows.js
@@ -128,7 +128,7 @@ exports.dispatchEvent = (event, data) => {
     timerWindow.webContents.send(event, data);
   }
   if (configWindow) {
-    configWindow.instance.webContents.send(event, data);
+    configWindow.sendEvent(event, data);
   }
   if (fullscreenWindow) {
     fullscreenWindow.webContents.send(event, data);

--- a/src/windows/windows.js
+++ b/src/windows/windows.js
@@ -3,9 +3,12 @@ const { app } = electron;
 const { snapCheck } = require("./window-snapper");
 const path = require("path");
 const { debounce } = require("debounce");
-const { createConfigWindow } = require("./config/initialize");
+const {
+  showConfigWindow,
+  sendEventToConfigWindow
+} = require("./config/initialize");
 
-let timerWindow, configWindow, fullscreenWindow;
+let timerWindow, fullscreenWindow;
 let snapThreshold, secondsUntilFullscreen, timerAlwaysOnTop;
 const timerWindowSize = {
   width: 220,
@@ -70,14 +73,7 @@ exports.createTimerWindow = () => {
   });
 };
 
-exports.showConfigWindow = () => {
-  if (configWindow) {
-    configWindow.showWindow();
-    return;
-  }
-  configWindow = createConfigWindow();
-  configWindow.onClose(() => (configWindow = null));
-};
+exports.showConfigWindow = showConfigWindow;
 
 exports.createFullscreenWindow = () => {
   if (fullscreenWindow) {
@@ -119,9 +115,9 @@ exports.dispatchEvent = (event, data) => {
   if (timerWindow) {
     timerWindow.webContents.send(event, data);
   }
-  if (configWindow) {
-    configWindow.sendEvent(event, data);
-  }
+
+  sendEventToConfigWindow(event, data);
+
   if (fullscreenWindow) {
     fullscreenWindow.webContents.send(event, data);
   }

--- a/src/windows/windows.js
+++ b/src/windows/windows.js
@@ -3,6 +3,7 @@ const { app } = electron;
 const { snapCheck } = require("./window-snapper");
 const path = require("path");
 const { debounce } = require("debounce");
+const { createConfigWindow } = require("./config/initialize");
 
 let timerWindow, configWindow, fullscreenWindow;
 let snapThreshold, secondsUntilFullscreen, timerAlwaysOnTop;
@@ -71,7 +72,7 @@ exports.createTimerWindow = () => {
 
 exports.showConfigWindow = () => {
   if (configWindow) {
-    configWindow.show();
+    configWindow.instance.show();
     return;
   }
   exports.createConfigWindow();
@@ -82,17 +83,8 @@ exports.createConfigWindow = () => {
     return;
   }
 
-  configWindow = new electron.BrowserWindow({
-    width: 420,
-    height: 500,
-    autoHideMenuBar: true,
-    webPreferences: {
-      nodeIntegration: true
-    }
-  });
-
-  configWindow.loadURL(`file://${__dirname}/config/index.html`);
-  configWindow.on("closed", () => (configWindow = null));
+  configWindow = createConfigWindow();
+  configWindow.instance.on("closed", () => (configWindow = null));
 };
 
 exports.createFullscreenWindow = () => {
@@ -136,7 +128,7 @@ exports.dispatchEvent = (event, data) => {
     timerWindow.webContents.send(event, data);
   }
   if (configWindow) {
-    configWindow.webContents.send(event, data);
+    configWindow.instance.webContents.send(event, data);
   }
   if (fullscreenWindow) {
     fullscreenWindow.webContents.send(event, data);


### PR DESCRIPTION
As a user of mob timer
In order to have a better experience
I want the timer window to be a bit higher and not have scroll by default

As a developer
In order to optimize for deletion and to have higher cohesion
I want the knowledge about config window creation to be in the `config` folder

# What

- Move `new BrowserWindow` call and other config window relate things into `config/initialize.js`
- Increase initial height of config window to fit all settings and up to three mobbers.