### PR TITLE
Move from assert to expect

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -26,6 +26,17 @@
           "electron"
         ]
       }
+    ],
+    "no-restricted-modules": [
+      "error",
+      {
+        "paths": [
+          {
+            "name": "assert",
+            "message": "\n\tPlease use the global expect provided by jest instead.\n\tDocumentation at https://jestjs.io/docs/en/expect.html\n"
+          }
+        ]
+      }
     ]
   }
 }

--- a/src/state/mobbers.test.js
+++ b/src/state/mobbers.test.js
@@ -12,7 +12,7 @@ describe("Mobbers", () => {
   describe("on construction", () => {
     it("should have no mobbers", () => {
       let result = mobbers.getAll();
-      assert.deepStrictEqual(result, []);
+      expect(result).toEqual([]);
     });
   });
 
@@ -82,7 +82,7 @@ describe("Mobbers", () => {
   describe("getCurrentAndNextMobbers", () => {
     it("return null values if there are no mobbers", () => {
       let result = mobbers.getCurrentAndNextMobbers();
-      assert.deepStrictEqual(result, { current: null, next: null });
+      expect(result).toEqual({ current: null, next: null });
     });
 
     it("return the same mobber for current and next if there is only one mobber", () => {
@@ -124,7 +124,7 @@ describe("Mobbers", () => {
     it("should do nothing when there are no mobbers", () => {
       mobbers.rotate();
       let result = mobbers.getCurrentAndNextMobbers();
-      assert.deepStrictEqual(result, { current: null, next: null });
+      expect(result).toEqual({ current: null, next: null });
     });
 
     it("should do nothing when there is only one mobber", () => {

--- a/src/state/mobbers.test.js
+++ b/src/state/mobbers.test.js
@@ -1,5 +1,4 @@
 let Mobbers = require("./mobbers");
-let assert = require("assert");
 const sinon = require("sinon");
 
 describe("Mobbers", () => {
@@ -42,7 +41,7 @@ describe("Mobbers", () => {
       mobbers.shuffleMobbers();
 
       const mobberIds = mobbers.getAll().map(mobber => mobber.id);
-      assert.deepStrictEqual(mobberIds, [
+      expect(mobberIds).toEqual([
         "mobber-1",
         "mobber-3",
         "mobber-4",
@@ -55,27 +54,27 @@ describe("Mobbers", () => {
     it("should add a mobber", () => {
       mobbers.addMobber({ name: "Test" });
       let result = mobbers.getAll();
-      assert.strictEqual(result[0].name, "Test");
+      expect(result[0].name).toBe("Test");
     });
 
     it("should add an id to the mobber if missing", () => {
       mobbers.addMobber({ name: "Test" });
       let result = mobbers.getAll();
-      assert.notStrictEqual(result[0].id, undefined);
+      expect(result[0].id).not.toBe(undefined);
     });
 
     it("should NOT add an id to the mobber if it already has one", () => {
       mobbers.addMobber({ id: "test-id", name: "Test" });
       let result = mobbers.getAll();
-      assert.strictEqual(result[0].id, "test-id");
+      expect(result[0].id).toBe("test-id");
     });
 
     it("should always add to the end of the list", () => {
       mobbers.addMobber({ name: "Test 1" });
       mobbers.addMobber({ name: "Test 2" });
       let result = mobbers.getAll();
-      assert.strictEqual(result[0].name, "Test 1");
-      assert.strictEqual(result[1].name, "Test 2");
+      expect(result[0].name).toBe("Test 1");
+      expect(result[1].name).toBe("Test 2");
     });
   });
 
@@ -88,16 +87,16 @@ describe("Mobbers", () => {
     it("return the same mobber for current and next if there is only one mobber", () => {
       mobbers.addMobber({ name: "Test" });
       let result = mobbers.getCurrentAndNextMobbers();
-      assert.strictEqual(result.current.name, "Test");
-      assert.strictEqual(result.next.name, "Test");
+      expect(result.current.name).toBe("Test");
+      expect(result.next.name).toBe("Test");
     });
 
     it("return the current and next mobber when there are 2 mobbers", () => {
       mobbers.addMobber({ name: "Test 1" });
       mobbers.addMobber({ name: "Test 2" });
       let result = mobbers.getCurrentAndNextMobbers();
-      assert.strictEqual(result.current.name, "Test 1");
-      assert.strictEqual(result.next.name, "Test 2");
+      expect(result.current.name).toBe("Test 1");
+      expect(result.next.name).toBe("Test 2");
     });
 
     it("should return the correct mobbers after rotating", () => {
@@ -106,8 +105,8 @@ describe("Mobbers", () => {
       mobbers.addMobber({ name: "Test 3" });
       mobbers.rotate();
       let result = mobbers.getCurrentAndNextMobbers();
-      assert.strictEqual(result.current.name, "Test 2");
-      assert.strictEqual(result.next.name, "Test 3");
+      expect(result.current.name).toBe("Test 2");
+      expect(result.next.name).toBe("Test 3");
     });
 
     it("should not include disabled mobbers", () => {
@@ -115,8 +114,8 @@ describe("Mobbers", () => {
       mobbers.addMobber({ name: "Test 2", disabled: true });
       mobbers.addMobber({ name: "Test 3" });
       let result = mobbers.getCurrentAndNextMobbers();
-      assert.strictEqual(result.current.name, "Test 1");
-      assert.strictEqual(result.next.name, "Test 3");
+      expect(result.current.name).toBe("Test 1");
+      expect(result.next.name).toBe("Test 3");
     });
   });
 
@@ -131,8 +130,8 @@ describe("Mobbers", () => {
       mobbers.addMobber({ name: "Test" });
       mobbers.rotate();
       let result = mobbers.getCurrentAndNextMobbers();
-      assert.strictEqual(result.current.name, "Test");
-      assert.strictEqual(result.next.name, "Test");
+      expect(result.current.name).toBe("Test");
+      expect(result.next.name).toBe("Test");
     });
 
     it("should rotate the mobbers when there are 2", () => {
@@ -140,8 +139,8 @@ describe("Mobbers", () => {
       mobbers.addMobber({ name: "Test 2" });
       mobbers.rotate();
       let result = mobbers.getCurrentAndNextMobbers();
-      assert.strictEqual(result.current.name, "Test 2");
-      assert.strictEqual(result.next.name, "Test 1");
+      expect(result.current.name).toBe("Test 2");
+      expect(result.next.name).toBe("Test 1");
     });
 
     it("should loop back around after the end of the list", () => {
@@ -150,8 +149,8 @@ describe("Mobbers", () => {
       mobbers.rotate();
       mobbers.rotate();
       let result = mobbers.getCurrentAndNextMobbers();
-      assert.strictEqual(result.current.name, "Test 1");
-      assert.strictEqual(result.next.name, "Test 2");
+      expect(result.current.name).toBe("Test 1");
+      expect(result.next.name).toBe("Test 2");
     });
 
     it("should skip disabled mobbers", () => {
@@ -163,8 +162,8 @@ describe("Mobbers", () => {
       mobbers.rotate();
       mobbers.rotate();
       let result = mobbers.getCurrentAndNextMobbers();
-      assert.strictEqual(result.current.name, "Test 2");
-      assert.strictEqual(result.next.name, "Test 5");
+      expect(result.current.name).toBe("Test 2");
+      expect(result.next.name).toBe("Test 5");
     });
   });
 
@@ -173,7 +172,7 @@ describe("Mobbers", () => {
       mobbers.addMobber({ name: "Test", id: "test-id" });
       mobbers.removeMobber({ name: "Other", id: "other-id" });
       let result = mobbers.getAll();
-      assert.strictEqual(result[0].name, "Test");
+      expect(result[0].name).toBe("Test");
     });
 
     it("should remove the mobber that matches by id", () => {
@@ -183,10 +182,10 @@ describe("Mobbers", () => {
       mobbers.addMobber({ name: "Test 2", id: "2b" });
       mobbers.removeMobber({ name: "Test 1", id: "1b" });
       let result = mobbers.getAll();
-      assert.strictEqual(result.length, 3);
-      assert.strictEqual(result[0].id, "1a");
-      assert.strictEqual(result[1].id, "2a");
-      assert.strictEqual(result[2].id, "2b");
+      expect(result.length).toBe(3);
+      expect(result[0].id).toBe("1a");
+      expect(result[1].id).toBe("2a");
+      expect(result[2].id).toBe("2b");
     });
 
     it("should update correctly if the removed mobber was the current mobber", () => {
@@ -196,8 +195,8 @@ describe("Mobbers", () => {
       mobbers.rotate();
       mobbers.removeMobber({ id: "t2" });
       let result = mobbers.getCurrentAndNextMobbers();
-      assert.strictEqual(result.current.name, "Test 3");
-      assert.strictEqual(result.next.name, "Test 1");
+      expect(result.current.name).toBe("Test 3");
+      expect(result.next.name).toBe("Test 1");
     });
 
     it("should wrap around correctly if the removed mobber was current and at the end of the list", () => {
@@ -208,8 +207,8 @@ describe("Mobbers", () => {
       mobbers.rotate();
       mobbers.removeMobber({ id: "t3" });
       let result = mobbers.getCurrentAndNextMobbers();
-      assert.strictEqual(result.current.name, "Test 1");
-      assert.strictEqual(result.next.name, "Test 2");
+      expect(result.current.name).toBe("Test 1");
+      expect(result.next.name).toBe("Test 2");
     });
 
     it("should wrap around correctly even if some mobbers are disabled", () => {
@@ -219,8 +218,8 @@ describe("Mobbers", () => {
       mobbers.rotate();
       mobbers.removeMobber({ id: "t3" });
       let result = mobbers.getCurrentAndNextMobbers();
-      assert.strictEqual(result.current.name, "Test 1");
-      assert.strictEqual(result.next.name, "Test 1");
+      expect(result.current.name).toBe("Test 1");
+      expect(result.next.name).toBe("Test 1");
     });
   });
 
@@ -235,11 +234,11 @@ describe("Mobbers", () => {
         image: "image-path"
       });
       let result = mobbers.getAll();
-      assert.strictEqual(result.length, 3);
-      assert.strictEqual(result[0].name, "Test 1");
-      assert.strictEqual(result[1].name, "Test 2-updated");
-      assert.strictEqual(result[2].name, "Test 3");
-      assert.strictEqual(result[1].image, "image-path");
+      expect(result.length).toBe(3);
+      expect(result[0].name).toBe("Test 1");
+      expect(result[1].name).toBe("Test 2-updated");
+      expect(result[2].name).toBe("Test 3");
+      expect(result[1].image).toBe("image-path");
     });
 
     it("should not replace anything if the id does not match", () => {
@@ -250,10 +249,10 @@ describe("Mobbers", () => {
         image: "image-path"
       });
       let result = mobbers.getAll();
-      assert.strictEqual(result.length, 1);
-      assert.strictEqual(result[0].name, "Test");
-      assert.strictEqual(result[0].id, "test-id");
-      assert.strictEqual(result[0].image, undefined);
+      expect(result.length).toBe(1);
+      expect(result[0].name).toBe("Test");
+      expect(result[0].id).toBe("test-id");
+      expect(result[0].image).toBe(undefined);
     });
 
     it("should not change the current mobber when enabling another", () => {
@@ -263,13 +262,13 @@ describe("Mobbers", () => {
 
       mobbers.rotate();
       let result = mobbers.getCurrentAndNextMobbers();
-      assert.strictEqual(result.current.name, "Test 3");
-      assert.strictEqual(result.next.name, "Test 1");
+      expect(result.current.name).toBe("Test 3");
+      expect(result.next.name).toBe("Test 1");
 
       mobbers.updateMobber({ name: "Test 2", id: "t2", disabled: false });
       result = mobbers.getCurrentAndNextMobbers();
-      assert.strictEqual(result.current.name, "Test 3");
-      assert.strictEqual(result.next.name, "Test 1");
+      expect(result.current.name).toBe("Test 3");
+      expect(result.next.name).toBe("Test 1");
     });
 
     it("should not change the current mobber when disabling another", () => {
@@ -279,13 +278,13 @@ describe("Mobbers", () => {
 
       mobbers.rotate();
       let result = mobbers.getCurrentAndNextMobbers();
-      assert.strictEqual(result.current.name, "Test 2");
-      assert.strictEqual(result.next.name, "Test 3");
+      expect(result.current.name).toBe("Test 2");
+      expect(result.next.name).toBe("Test 3");
 
       mobbers.updateMobber({ name: "Test 1", id: "t1", disabled: true });
       result = mobbers.getCurrentAndNextMobbers();
-      assert.strictEqual(result.current.name, "Test 2");
-      assert.strictEqual(result.next.name, "Test 3");
+      expect(result.current.name).toBe("Test 2");
+      expect(result.next.name).toBe("Test 3");
     });
 
     it("should go to the next mobber when disabling the current mobber", () => {
@@ -294,13 +293,13 @@ describe("Mobbers", () => {
       mobbers.addMobber({ name: "Test 3", id: "t3" });
 
       let result = mobbers.getCurrentAndNextMobbers();
-      assert.strictEqual(result.current.name, "Test 1");
-      assert.strictEqual(result.next.name, "Test 2");
+      expect(result.current.name).toBe("Test 1");
+      expect(result.next.name).toBe("Test 2");
 
       mobbers.updateMobber({ name: "Test 1", id: "t1", disabled: true });
       result = mobbers.getCurrentAndNextMobbers();
-      assert.strictEqual(result.current.name, "Test 2");
-      assert.strictEqual(result.next.name, "Test 3");
+      expect(result.current.name).toBe("Test 2");
+      expect(result.next.name).toBe("Test 3");
     });
 
     it("should wrap around to the first mobber when disabling the current last mobber", () => {
@@ -311,13 +310,13 @@ describe("Mobbers", () => {
       mobbers.rotate();
       mobbers.rotate();
       let result = mobbers.getCurrentAndNextMobbers();
-      assert.strictEqual(result.current.name, "Test 3");
-      assert.strictEqual(result.next.name, "Test 1");
+      expect(result.current.name).toBe("Test 3");
+      expect(result.next.name).toBe("Test 1");
 
       mobbers.updateMobber({ name: "Test 3", id: "t3", disabled: true });
       result = mobbers.getCurrentAndNextMobbers();
-      assert.strictEqual(result.current.name, "Test 1");
-      assert.strictEqual(result.next.name, "Test 2");
+      expect(result.current.name).toBe("Test 1");
+      expect(result.next.name).toBe("Test 2");
     });
   });
 });

--- a/src/state/state-persister.test.js
+++ b/src/state/state-persister.test.js
@@ -1,7 +1,6 @@
 const persister = require("./state-persister");
 const sinon = require("sinon");
 const fs = require("fs");
-const assert = require("assert");
 
 describe("state-persister", () => {
   const sandbox = sinon.createSandbox();
@@ -28,7 +27,7 @@ describe("state-persister", () => {
         .callsFake(() => true);
 
       const result = persister.read();
-      assert.deepStrictEqual(result, stateData);
+      expect(result).toEqual(stateData);
     });
 
     it("should look for the old state file if the new one does not exist", () => {
@@ -40,7 +39,7 @@ describe("state-persister", () => {
         .callsFake(() => true);
 
       const result = persister.read();
-      assert.deepStrictEqual(result, oldStateData);
+      expect(result).toEqual(oldStateData);
     });
 
     it("should return an empty object if no state file exists", () => {
@@ -52,7 +51,7 @@ describe("state-persister", () => {
         .callsFake(() => false);
 
       const result = persister.read();
-      assert.deepStrictEqual(result, {});
+      expect(result).toEqual({});
     });
   });
 

--- a/src/state/timer-state.test.js
+++ b/src/state/timer-state.test.js
@@ -134,12 +134,17 @@ describe("timer-state", () => {
 
     it("should publish a rotated event", () => {
       var event = assertEvent("rotated");
-      assert.strictEqual(
-        event.data.current.name,
-        "B",
-        "expected B to be current"
-      );
-      assert.strictEqual(event.data.next.name, "C", "expected C to be next");
+
+      const actual = {
+        currentName: event.data.current.name,
+        nextName: event.data.next.name
+      };
+
+      const expectations = {
+        currentName: "B",
+        nextName: "C"
+      };
+      expect(actual).toEqual(expectations);
     });
 
     it("should publish a timerChange event", () => {
@@ -154,12 +159,16 @@ describe("timer-state", () => {
       events = [];
       timerState.rotate();
       var event = assertEvent("rotated");
-      assert.strictEqual(
-        event.data.current.name,
-        "C",
-        "expected C to be current"
-      );
-      assert.strictEqual(event.data.next.name, "A", "expected A to be next");
+      const actual = {
+        currentName: event.data.current.name,
+        nextName: event.data.next.name
+      };
+
+      const expectations = {
+        currentName: "C",
+        nextName: "A"
+      };
+      expect(actual).toEqual(expectations);
     });
   });
 
@@ -208,8 +217,16 @@ describe("timer-state", () => {
 
     it("should publish a rotated event", () => {
       var event = assertEvent("rotated");
-      expect(event.data.current.name).toBe("A");
-      expect(event.data.next.name).toBe("A");
+      const actual = {
+        currentName: event.data.current.name,
+        nextName: event.data.next.name
+      };
+
+      const expectations = {
+        currentName: "A",
+        nextName: "A"
+      };
+      expect(actual).toEqual(expectations);
     });
   });
 
@@ -231,8 +248,16 @@ describe("timer-state", () => {
 
     it("should publish a rotated event", () => {
       var event = assertEvent("rotated");
-      expect(event.data.current.name).toBe("A");
-      expect(event.data.next.name).toBe("C");
+      const actual = {
+        currentName: event.data.current.name,
+        nextName: event.data.next.name
+      };
+
+      const expectations = {
+        currentName: "A",
+        nextName: "C"
+      };
+      expect(actual).toEqual(expectations);
     });
 
     it("should NOT publish a turnEnded event if the removed user was NOT current", () => {

--- a/src/state/timer-state.test.js
+++ b/src/state/timer-state.test.js
@@ -1,6 +1,5 @@
 let TimerState = require("./timer-state");
 let TestTimer = require("./test-timer");
-let assert = require("assert");
 
 describe("timer-state", () => {
   let timerState;
@@ -25,7 +24,7 @@ describe("timer-state", () => {
 
     it("should publish a timerChange event", () => {
       var event = assertEvent("timerChange");
-      assert.deepStrictEqual(event.data, {
+      expect(event.data).toEqual({
         secondsRemaining: 600,
         secondsPerTurn: 600
       });
@@ -50,7 +49,7 @@ describe("timer-state", () => {
 
     it("should publish a timerChange event", () => {
       var event = assertEvent("timerChange");
-      assert.deepStrictEqual(event.data, {
+      expect(event.data).toEqual({
         secondsRemaining: 600,
         secondsPerTurn: 600
       });
@@ -61,7 +60,7 @@ describe("timer-state", () => {
     beforeEach(() => timerState.start());
 
     it("should start the mainTimer", function() {
-      assert.strictEqual(timerState.mainTimer.isRunning, true);
+      expect(timerState.mainTimer.isRunning).toBe(true);
     });
 
     it("should publish a started event", () => {
@@ -75,7 +74,7 @@ describe("timer-state", () => {
     it("should publish a timerChange event when the timer calls back", () => {
       timerState.mainTimer.callback(599);
       var event = assertEvent("timerChange");
-      assert.deepStrictEqual(event.data, {
+      expect(event.data).toEqual({
         secondsRemaining: 599,
         secondsPerTurn: 600
       });
@@ -87,19 +86,19 @@ describe("timer-state", () => {
       assertEvent("paused");
       assertEvent("rotated");
       var alertEvent = assertEvent("alert");
-      assert.strictEqual(alertEvent.data, 0);
+      expect(alertEvent.data).toBe(0);
     });
 
     it("should start the alertsTimer after the timer is up", () => {
-      assert.strictEqual(timerState.alertsTimer.isRunning, false);
+      expect(timerState.alertsTimer.isRunning).toBe(false);
       timerState.mainTimer.callback(-1);
-      assert.strictEqual(timerState.alertsTimer.isRunning, true);
+      expect(timerState.alertsTimer.isRunning).toBe(true);
     });
 
     it("should publish alert events after the time is up", () => {
       timerState.alertsTimer.callback(1);
       var event = assertEvent("alert");
-      assert.strictEqual(event.data, 1);
+      expect(event.data).toBe(1);
     });
   });
 
@@ -116,10 +115,10 @@ describe("timer-state", () => {
 
     it("should stop the mainTimer", () => {
       timerState.start();
-      assert.strictEqual(timerState.mainTimer.isRunning, true);
+      expect(timerState.mainTimer.isRunning).toBe(true);
 
       timerState.pause();
-      assert.strictEqual(timerState.mainTimer.isRunning, false);
+      expect(timerState.mainTimer.isRunning).toBe(false);
     });
   });
 
@@ -144,7 +143,7 @@ describe("timer-state", () => {
 
     it("should publish a timerChange event", () => {
       var event = assertEvent("timerChange");
-      assert.deepStrictEqual(event.data, {
+      expect(event.data).toEqual({
         secondsRemaining: 600,
         secondsPerTurn: 600
       });
@@ -169,13 +168,13 @@ describe("timer-state", () => {
     it("should publish a configUpdated event", () => {
       var event = assertEvent("configUpdated");
       expect(event.data.mobbers).toEqual([]);
-      assert.strictEqual(event.data.secondsPerTurn, 600);
-      assert.strictEqual(event.data.secondsUntilFullscreen, 30);
-      assert.strictEqual(event.data.snapThreshold, 25);
-      assert.strictEqual(event.data.alertSound, null);
+      expect(event.data.secondsPerTurn).toBe(600);
+      expect(event.data.secondsUntilFullscreen).toBe(30);
+      expect(event.data.snapThreshold).toBe(25);
+      expect(event.data.alertSound).toBe(null);
       expect(event.data.alertSoundTimes).toEqual([]);
-      assert.strictEqual(event.data.timerAlwaysOnTop, true);
-      assert.strictEqual(event.data.shuffleMobbersOnStartup, false);
+      expect(event.data.timerAlwaysOnTop).toBe(true);
+      expect(event.data.shuffleMobbersOnStartup).toBe(false);
     });
 
     it("should contain the mobbers if there are some", () => {
@@ -185,8 +184,8 @@ describe("timer-state", () => {
 
       timerState.publishConfig();
       var event = assertEvent("configUpdated");
-      assert.strictEqual(event.data.mobbers[0].name, "A");
-      assert.strictEqual(event.data.mobbers[1].name, "B");
+      expect(event.data.mobbers[0].name).toBe("A");
+      expect(event.data.mobbers[1].name).toBe("B");
 
       timerState.removeMobber({ name: "A" });
       timerState.removeMobber({ name: "B" });
@@ -202,14 +201,14 @@ describe("timer-state", () => {
 
     it("should publish a configUpdated event", () => {
       var event = assertEvent("configUpdated");
-      assert.strictEqual(event.data.mobbers[0].name, "A");
-      assert.strictEqual(event.data.secondsPerTurn, 600);
+      expect(event.data.mobbers[0].name).toBe("A");
+      expect(event.data.secondsPerTurn).toBe(600);
     });
 
     it("should publish a rotated event", () => {
       var event = assertEvent("rotated");
-      assert.strictEqual(event.data.current.name, "A");
-      assert.strictEqual(event.data.next.name, "A");
+      expect(event.data.current.name).toBe("A");
+      expect(event.data.next.name).toBe("A");
     });
   });
 
@@ -224,20 +223,20 @@ describe("timer-state", () => {
 
     it("should publish a configUpdated event", () => {
       var event = assertEvent("configUpdated");
-      assert.strictEqual(event.data.mobbers[0].name, "A");
-      assert.strictEqual(event.data.mobbers[1].name, "C");
-      assert.strictEqual(event.data.secondsPerTurn, 600);
+      expect(event.data.mobbers[0].name).toBe("A");
+      expect(event.data.mobbers[1].name).toBe("C");
+      expect(event.data.secondsPerTurn).toBe(600);
     });
 
     it("should publish a rotated event", () => {
       var event = assertEvent("rotated");
-      assert.strictEqual(event.data.current.name, "A");
-      assert.strictEqual(event.data.next.name, "C");
+      expect(event.data.current.name).toBe("A");
+      expect(event.data.next.name).toBe("C");
     });
 
     it("should NOT publish a turnEnded event if the removed user was NOT current", () => {
       var event = events.find(x => x.event === "turnEnded");
-      assert.strictEqual(event, undefined);
+      expect(event).toBe(undefined);
     });
 
     it("should publish a turnEnded event if the removed user was current", () => {
@@ -260,8 +259,8 @@ describe("timer-state", () => {
       events = [];
       timerState.removeMobber({ name: "C", id: "c" });
       var event = assertEvent("rotated");
-      assert.strictEqual(event.data.current.name, "A");
-      assert.strictEqual(event.data.next.name, "A");
+      expect(event.data.current.name).toBe("A");
+      expect(event.data.next.name).toBe("A");
     });
   });
 
@@ -274,8 +273,8 @@ describe("timer-state", () => {
 
     it("should publish a configUpdated event", () => {
       var event = assertEvent("configUpdated");
-      assert.strictEqual(event.data.mobbers[0].name, "A2");
-      assert.strictEqual(event.data.secondsPerTurn, 600);
+      expect(event.data.mobbers[0].name).toBe("A2");
+      expect(event.data.secondsPerTurn).toBe(600);
     });
 
     it("should update correctly if the update disabled the current mobber", () => {
@@ -290,10 +289,10 @@ describe("timer-state", () => {
       assertEvent("turnEnded");
       assertEvent("configUpdated");
       var rotatedEvent = assertEvent("rotated");
-      assert.strictEqual(rotatedEvent.data.current.name, "C");
-      assert.strictEqual(rotatedEvent.data.next.name, "A2");
+      expect(rotatedEvent.data.current.name).toBe("C");
+      expect(rotatedEvent.data.next.name).toBe("A2");
       var timerChangeEvent = assertEvent("timerChange");
-      assert.deepStrictEqual(timerChangeEvent.data, {
+      expect(timerChangeEvent.data).toEqual({
         secondsRemaining: 600,
         secondsPerTurn: 600
       });
@@ -321,7 +320,7 @@ describe("timer-state", () => {
         .getState()
         .mobbers.map(x => x.id)
         .join("");
-      assert.notStrictEqual(mobbers, "abcdefghij");
+      expect(mobbers).not.toBe("abcdefghij");
     });
   });
 
@@ -330,12 +329,12 @@ describe("timer-state", () => {
 
     it("should publish a configUpdated event", () => {
       var event = assertEvent("configUpdated");
-      assert.strictEqual(event.data.secondsPerTurn, 300);
+      expect(event.data.secondsPerTurn).toBe(300);
     });
 
     it("should publish a timerChange event", () => {
       var event = assertEvent("timerChange");
-      assert.deepStrictEqual(event.data, {
+      expect(event.data).toEqual({
         secondsRemaining: 300,
         secondsPerTurn: 300
       });
@@ -347,7 +346,7 @@ describe("timer-state", () => {
 
     it("should publish a configUpdated event", () => {
       var event = assertEvent("configUpdated");
-      assert.strictEqual(event.data.secondsUntilFullscreen, 5);
+      expect(event.data.secondsUntilFullscreen).toBe(5);
     });
   });
 
@@ -356,7 +355,7 @@ describe("timer-state", () => {
 
     it("should publish configUpdated event", () => {
       var event = assertEvent("configUpdated");
-      assert.strictEqual(event.data.snapThreshold, 100);
+      expect(event.data.snapThreshold).toBe(100);
     });
   });
 
@@ -365,7 +364,7 @@ describe("timer-state", () => {
 
     it("should publish a configUpdated event", () => {
       var event = assertEvent("configUpdated");
-      assert.strictEqual(event.data.alertSound, "new-sound.mp3");
+      expect(event.data.alertSound).toBe("new-sound.mp3");
     });
   });
 
@@ -421,35 +420,33 @@ describe("timer-state", () => {
       });
 
       it("should get correct seconds per turn", () => {
-        assert.strictEqual(result.secondsPerTurn, expectedSecondsPerTurn);
+        expect(result.secondsPerTurn).toBe(expectedSecondsPerTurn);
       });
 
       it("should get the correct seconds until fullscreen", () => {
-        assert.strictEqual(
-          result.secondsUntilFullscreen,
+        expect(result.secondsUntilFullscreen).toBe(
           expectedSecondsUntilFullscreen
         );
       });
 
       it("should get the correct snap threshold", () => {
-        assert.strictEqual(result.snapThreshold, expectedSnapThreshold);
+        expect(result.snapThreshold).toBe(expectedSnapThreshold);
       });
 
       it("should get the correct alert sound", () => {
-        assert.strictEqual(result.alertSound, expectedAlertSound);
+        expect(result.alertSound).toBe(expectedAlertSound);
       });
 
       it("should get the correct alert sound times", () => {
-        assert.strictEqual(result.alertSoundTimes, expectedAlertSoundTimes);
+        expect(result.alertSoundTimes).toBe(expectedAlertSoundTimes);
       });
 
       it("should get the correct timer always on top", () => {
-        assert.strictEqual(result.timerAlwaysOnTop, expectedTimerAlwaysOnTop);
+        expect(result.timerAlwaysOnTop).toBe(expectedTimerAlwaysOnTop);
       });
 
       it("should get the correct shuffle mobbers on startup", () => {
-        assert.strictEqual(
-          result.shuffleMobbersOnStartup,
+        expect(result.shuffleMobbersOnStartup).toBe(
           expectedShuffleMobbersOnStartup
         );
       });
@@ -469,19 +466,20 @@ describe("timer-state", () => {
     describe("when getting default state", () => {
       beforeEach(() => (result = timerState.getState()));
 
-      it("should get no mobbers", () => assert(result.mobbers.length === 0));
+      it("should get no mobbers", () =>
+        expect(result.mobbers.length).toEqual(0));
       it("should have a default secondsPerTurn greater than zero", () =>
-        assert(result.secondsPerTurn > 0));
+        expect(result.secondsPerTurn).toBeGreaterThan(0));
       it("should have a default snapThreshold greater than zero", () =>
-        assert(result.snapThreshold > 0));
+        expect(result.snapThreshold).toBeGreaterThan(0));
       it("should have a null alert sound", () =>
-        assert(result.alertSound === null));
+        expect(result.alertSound).toBeNull());
       it("should have an empty array of alert sound times", () =>
         expect(result.alertSoundTimes).toEqual([]));
       it("should have a default timerAlwaysOnTop", () =>
         expect(result.timerAlwaysOnTop).toEqual(true));
       it("should have a default shuffleMobbersOnStartup", () =>
-        assert.strictEqual(result.shuffleMobbersOnStartup, false));
+        expect(result.shuffleMobbersOnStartup).toBe(false));
 
       let result = {};
     });
@@ -526,23 +524,21 @@ describe("timer-state", () => {
       it("should load mobbers", () =>
         expect(result.mobbers).toEqual(state.mobbers));
       it("should load secondsPerTurn", () =>
-        assert.strictEqual(result.secondsPerTurn, state.secondsPerTurn));
+        expect(result.secondsPerTurn).toBe(state.secondsPerTurn));
       it("should load secondsUntilFullscreen", () =>
-        assert.strictEqual(
-          result.secondsUntilFullscreen,
+        expect(result.secondsUntilFullscreen).toBe(
           state.secondsUntilFullscreen
         ));
       it("should load snapThreshold", () =>
-        assert.strictEqual(result.snapThreshold, state.snapThreshold));
+        expect(result.snapThreshold).toBe(state.snapThreshold));
       it("should load alertSound", () =>
-        assert.strictEqual(result.alertSound, state.alertSound));
+        expect(result.alertSound).toBe(state.alertSound));
       it("should load alertSoundTimes", () =>
         expect(result.alertSoundTimes).toEqual([2, 3, 5, 8]));
       it("should load timerAlwaysOnTop", () =>
-        assert.strictEqual(result.timerAlwaysOnTop, state.timerAlwaysOnTop));
+        expect(result.timerAlwaysOnTop).toBe(state.timerAlwaysOnTop));
       it("should load shuffleMobbersOnStartup", () =>
-        assert.strictEqual(
-          result.shuffleMobbersOnStartup,
+        expect(result.shuffleMobbersOnStartup).toBe(
           state.shuffleMobbersOnStartup
         ));
 
@@ -558,21 +554,21 @@ describe("timer-state", () => {
       });
 
       it("should NOT load any mobbers", () =>
-        assert.strictEqual(result.mobbers.length, 0));
+        expect(result.mobbers.length).toBe(0));
       it("should have a default secondsPerTurn greater than zero", () =>
-        assert(result.secondsPerTurn > 0));
+        expect(result.secondsPerTurn).toBeGreaterThan(0));
       it("should have a default secondsUntilFullscreen greater than zero", () =>
-        assert(result.secondsUntilFullscreen > 0));
+        expect(result.secondsUntilFullscreen).toBeGreaterThan(0));
       it("should have a default snapThreshold greater than zero", () =>
-        assert(result.snapThreshold > 0));
+        expect(result.snapThreshold).toBeGreaterThan(0));
       it("should have a null alertSound", () =>
-        assert.strictEqual(result.alertSound, null));
+        expect(result.alertSound).toBe(null));
       it("should have an empty array of alertSoundTimes", () =>
         expect(result.alertSoundTimes).toEqual([]));
       it("should have a default timerAlwaysOnTop", () =>
-        assert.strictEqual(result.timerAlwaysOnTop, true));
+        expect(result.timerAlwaysOnTop).toBe(true));
       it("should have a default shuffleMobbersOnStartup", () =>
-        assert.strictEqual(result.shuffleMobbersOnStartup, false));
+        expect(result.shuffleMobbersOnStartup).toBe(false));
 
       let result = {};
     });

--- a/src/state/timer-state.test.js
+++ b/src/state/timer-state.test.js
@@ -33,7 +33,7 @@ describe("timer-state", () => {
 
     it("should publish a rotated event", () => {
       var event = assertEvent("rotated");
-      assert.deepStrictEqual(event.data, { current: null, next: null });
+      expect(event.data).toEqual({ current: null, next: null });
     });
 
     it("should publish a turnEnded event", () => {
@@ -168,12 +168,12 @@ describe("timer-state", () => {
 
     it("should publish a configUpdated event", () => {
       var event = assertEvent("configUpdated");
-      assert.deepStrictEqual(event.data.mobbers, []);
+      expect(event.data.mobbers).toEqual([]);
       assert.strictEqual(event.data.secondsPerTurn, 600);
       assert.strictEqual(event.data.secondsUntilFullscreen, 30);
       assert.strictEqual(event.data.snapThreshold, 25);
       assert.strictEqual(event.data.alertSound, null);
-      assert.deepStrictEqual(event.data.alertSoundTimes, []);
+      expect(event.data.alertSoundTimes).toEqual([]);
       assert.strictEqual(event.data.timerAlwaysOnTop, true);
       assert.strictEqual(event.data.shuffleMobbersOnStartup, false);
     });
@@ -374,7 +374,7 @@ describe("timer-state", () => {
 
     it("should publish a configUpdated event", () => {
       var event = assertEvent("configUpdated");
-      assert.deepStrictEqual(event.data.alertSoundTimes, [1, 2, 3]);
+      expect(event.data.alertSoundTimes).toEqual([1, 2, 3]);
     });
   });
 
@@ -383,7 +383,7 @@ describe("timer-state", () => {
 
     it("should publish a configUpdated event", () => {
       var event = assertEvent("configUpdated");
-      assert.deepStrictEqual(event.data.timerAlwaysOnTop, false);
+      expect(event.data.timerAlwaysOnTop).toEqual(false);
     });
   });
 
@@ -392,7 +392,7 @@ describe("timer-state", () => {
 
     it("should publish a configUpdated event", () => {
       var event = assertEvent("configUpdated");
-      assert.deepStrictEqual(event.data.shuffleMobbersOnStartup, true);
+      expect(event.data.shuffleMobbersOnStartup).toEqual(true);
     });
   });
 
@@ -416,8 +416,8 @@ describe("timer-state", () => {
         var actualJack = result.mobbers.find(x => x.name === expectedJack.name);
         var actualJill = result.mobbers.find(x => x.name === expectedJill.name);
 
-        assert.deepStrictEqual(expectedJack, actualJack);
-        assert.deepStrictEqual(expectedJill, actualJill);
+        expect(expectedJack).toEqual(actualJack);
+        expect(expectedJill).toEqual(actualJill);
       });
 
       it("should get correct seconds per turn", () => {
@@ -477,9 +477,9 @@ describe("timer-state", () => {
       it("should have a null alert sound", () =>
         assert(result.alertSound === null));
       it("should have an empty array of alert sound times", () =>
-        assert.deepStrictEqual(result.alertSoundTimes, []));
+        expect(result.alertSoundTimes).toEqual([]));
       it("should have a default timerAlwaysOnTop", () =>
-        assert.deepStrictEqual(result.timerAlwaysOnTop, true));
+        expect(result.timerAlwaysOnTop).toEqual(true));
       it("should have a default shuffleMobbersOnStartup", () =>
         assert.strictEqual(result.shuffleMobbersOnStartup, false));
 
@@ -496,7 +496,7 @@ describe("timer-state", () => {
       it("should get correct mobber", () => {
         var actualJack = result.mobbers.find(x => x.name === expectedJack.name);
 
-        assert.deepStrictEqual(expectedJack, actualJack);
+        expect(expectedJack).toEqual(actualJack);
       });
 
       let result = {};
@@ -524,7 +524,7 @@ describe("timer-state", () => {
       });
 
       it("should load mobbers", () =>
-        assert.deepStrictEqual(result.mobbers, state.mobbers));
+        expect(result.mobbers).toEqual(state.mobbers));
       it("should load secondsPerTurn", () =>
         assert.strictEqual(result.secondsPerTurn, state.secondsPerTurn));
       it("should load secondsUntilFullscreen", () =>
@@ -537,7 +537,7 @@ describe("timer-state", () => {
       it("should load alertSound", () =>
         assert.strictEqual(result.alertSound, state.alertSound));
       it("should load alertSoundTimes", () =>
-        assert.deepStrictEqual(result.alertSoundTimes, [2, 3, 5, 8]));
+        expect(result.alertSoundTimes).toEqual([2, 3, 5, 8]));
       it("should load timerAlwaysOnTop", () =>
         assert.strictEqual(result.timerAlwaysOnTop, state.timerAlwaysOnTop));
       it("should load shuffleMobbersOnStartup", () =>
@@ -568,7 +568,7 @@ describe("timer-state", () => {
       it("should have a null alertSound", () =>
         assert.strictEqual(result.alertSound, null));
       it("should have an empty array of alertSoundTimes", () =>
-        assert.deepStrictEqual(result.alertSoundTimes, []));
+        expect(result.alertSoundTimes).toEqual([]));
       it("should have a default timerAlwaysOnTop", () =>
         assert.strictEqual(result.timerAlwaysOnTop, true));
       it("should have a default shuffleMobbersOnStartup", () =>
@@ -589,7 +589,7 @@ describe("timer-state", () => {
       });
 
       it("should load one mobber", () =>
-        assert.deepStrictEqual(state.mobbers, result.mobbers));
+        expect(state.mobbers).toEqual(result.mobbers));
 
       let result = {};
       let state = {};

--- a/src/state/timer-state.test.js
+++ b/src/state/timer-state.test.js
@@ -7,7 +7,8 @@ describe("timer-state", () => {
 
   let assertEvent = eventName => {
     var event = events.find(x => x.event === eventName);
-    assert(event, eventName + " event not found");
+    var failureMessage = event ? undefined : eventName + " event not found";
+    expect(failureMessage).toBeUndefined();
     return event;
   };
 

--- a/src/state/timer.test.js
+++ b/src/state/timer.test.js
@@ -1,5 +1,4 @@
 let Timer = require("./timer");
-let assert = require("assert");
 const sinon = require("sinon");
 
 describe("Timer", () => {
@@ -27,18 +26,15 @@ describe("Timer", () => {
   describe("on construction", () => {
     describe("with specified options", () => {
       it("should have the specified rateMilliseconds value", () => {
-        assert.strictEqual(
-          timer.rateMilliseconds,
-          timerOptions.rateMilliseconds
-        );
+        expect(timer.rateMilliseconds).toBe(timerOptions.rateMilliseconds);
       });
 
       it("should have the specified value", () => {
-        assert.strictEqual(timer.time, timerOptions.time);
+        expect(timer.time).toBe(timerOptions.time);
       });
 
       it("should have a change value based on the specified countDown", () => {
-        assert.strictEqual(timer.change, -1);
+        expect(timer.change).toBe(-1);
       });
     });
 
@@ -49,15 +45,15 @@ describe("Timer", () => {
       });
 
       it("should have the default rateMilliseconds value", () => {
-        assert.strictEqual(timer.rateMilliseconds, 1000);
+        expect(timer.rateMilliseconds).toBe(1000);
       });
 
       it("should have the default time value", () => {
-        assert.strictEqual(timer.time, 0);
+        expect(timer.time).toBe(0);
       });
 
       it("should have the default change value", () => {
-        assert.strictEqual(timer.change, 1);
+        expect(timer.change).toBe(1);
       });
     });
   });
@@ -66,7 +62,7 @@ describe("Timer", () => {
     it("should generate callbacks when counting down", () => {
       timer.start();
       clock.tick(50);
-      assert.strictEqual(callbacks.join(","), "49,48");
+      expect(callbacks.join(",")).toBe("49,48");
     });
 
     it("should generate callbacks when counting up", () => {
@@ -74,7 +70,7 @@ describe("Timer", () => {
       createTimer();
       timer.start();
       clock.tick(50);
-      assert.strictEqual(callbacks.join(","), "51,52");
+      expect(callbacks.join(",")).toBe("51,52");
     });
   });
 
@@ -84,14 +80,14 @@ describe("Timer", () => {
       clock.tick(50);
       timer.pause();
       clock.tick(100);
-      assert.strictEqual(callbacks.join(","), "49,48");
+      expect(callbacks.join(",")).toBe("49,48");
     });
   });
 
   describe("reset", () => {
     it("should set a new time value when the timer is not running", () => {
       timer.reset(42);
-      assert.strictEqual(timer.time, 42);
+      expect(timer.time).toBe(42);
     });
 
     it("should set a new time value when the timer is running", () => {
@@ -99,7 +95,7 @@ describe("Timer", () => {
       clock.tick(50);
       timer.reset(20);
       clock.tick(40);
-      assert.strictEqual(callbacks.join(","), "49,48,19,18");
+      expect(callbacks.join(",")).toBe("49,48,19,18");
     });
   });
 });

--- a/src/windows/window-snapper.test.js
+++ b/src/windows/window-snapper.test.js
@@ -1,5 +1,4 @@
 const { snapCheck } = require("./window-snapper");
-const assert = require("assert");
 
 describe("window-snapper snapCheck", () => {
   const fullHdScreen = { x: 0, y: 0, width: 1920, height: 1080 };
@@ -9,7 +8,7 @@ describe("window-snapper snapCheck", () => {
     const screenBounds = fullHdScreen;
     const snapThreshold = 0;
     const act = () => snapCheck(windowBounds, screenBounds, snapThreshold);
-    assert.throws(act);
+    expect(act).toThrow();
   });
 
   it("should not snap if far from edges", () => {
@@ -22,7 +21,7 @@ describe("window-snapper snapCheck", () => {
     const screenBounds = { x: 0, y: 0, width: 200, height: 200 };
     const snapThreshold = 10;
     const result = snapCheck(windowBounds, screenBounds, snapThreshold);
-    assert.deepStrictEqual(result, {
+    expect(result).toEqual({
       x: 11,
       y: 11,
       width: 178,
@@ -36,7 +35,7 @@ describe("window-snapper snapCheck", () => {
     const screenBounds = fullHdScreen;
     const snapThreshold = 10;
     const result = snapCheck(windowBounds, screenBounds, snapThreshold);
-    assert.deepStrictEqual(result, {
+    expect(result).toEqual({
       x: 0,
       y: 11,
       width: 220,
@@ -50,7 +49,7 @@ describe("window-snapper snapCheck", () => {
     const screenBounds = fullHdScreen;
     const snapThreshold = 10;
     const result = snapCheck(windowBounds, screenBounds, snapThreshold);
-    assert.deepStrictEqual(result, {
+    expect(result).toEqual({
       x: 0,
       y: 0,
       width: 220,
@@ -64,7 +63,7 @@ describe("window-snapper snapCheck", () => {
     const screenBounds = fullHdScreen;
     const snapThreshold = 10;
     const result = snapCheck(windowBounds, screenBounds, snapThreshold);
-    assert.deepStrictEqual(result, {
+    expect(result).toEqual({
       x: 14,
       y: 0,
       width: 220,
@@ -78,7 +77,7 @@ describe("window-snapper snapCheck", () => {
     const screenBounds = fullHdScreen;
     const snapThreshold = 10;
     const result = snapCheck(windowBounds, screenBounds, snapThreshold);
-    assert.deepStrictEqual(result, {
+    expect(result).toEqual({
       x: 1700,
       y: 0,
       width: 220,
@@ -92,7 +91,7 @@ describe("window-snapper snapCheck", () => {
     const screenBounds = fullHdScreen;
     const snapThreshold = 10;
     const result = snapCheck(windowBounds, screenBounds, snapThreshold);
-    assert.deepStrictEqual(result, {
+    expect(result).toEqual({
       x: 1700,
       y: 13,
       width: 220,
@@ -106,7 +105,7 @@ describe("window-snapper snapCheck", () => {
     const screenBounds = fullHdScreen;
     const snapThreshold = 10;
     const result = snapCheck(windowBounds, screenBounds, snapThreshold);
-    assert.deepStrictEqual(result, {
+    expect(result).toEqual({
       x: 1700,
       y: 990,
       width: 220,
@@ -120,7 +119,7 @@ describe("window-snapper snapCheck", () => {
     const screenBounds = fullHdScreen;
     const snapThreshold = 10;
     const result = snapCheck(windowBounds, screenBounds, snapThreshold);
-    assert.deepStrictEqual(result, {
+    expect(result).toEqual({
       x: 1685,
       y: 990,
       width: 220,
@@ -134,7 +133,7 @@ describe("window-snapper snapCheck", () => {
     const screenBounds = fullHdScreen;
     const snapThreshold = 10;
     const result = snapCheck(windowBounds, screenBounds, snapThreshold);
-    assert.deepStrictEqual(result, {
+    expect(result).toEqual({
       x: 0,
       y: 990,
       width: 220,

--- a/test/node-version.test.js
+++ b/test/node-version.test.js
@@ -8,7 +8,7 @@ describe("Node versions", () => {
   const { electronVersion, nodeVersion } = getMatchingElectronReleaseInfo();
 
   it(`should find node version used by electron (${electronVersion})`, () => {
-    assert.ok(nodeVersion.length, `Found: ${nodeVersion}`);
+    expect(nodeVersion.length).toBeTruthy();
   });
 
   it(`should find node version ${nodeVersion} in .nvmrc`, () => {
@@ -18,12 +18,14 @@ describe("Node versions", () => {
 
   it(`should find node version ${nodeVersion} in .travis.yml`, () => {
     const travisYml = fs.readFileSync("./.travis.yml", "utf-8");
-    const matches = travisYml.indexOf(`- "${nodeVersion}"`) !== -1;
-    const failMessage = [
-      `Could not find node version ${nodeVersion} in .travis.yml!`,
-      travisYml
-    ];
-    assert.ok(matches, failMessage.join("\n"));
+    const matches = travisYml.indexOf(`- "${nodeVersion}1"`) !== -1;
+    const failMessage = matches
+      ? undefined
+      : [
+          `Could not find node version ${nodeVersion} in .travis.yml!`,
+          travisYml
+        ].join("\n");
+    expect(failMessage).toBeUndefined();
   });
 
   it(`should find engines node version ${nodeVersion} in package.json`, () => {

--- a/test/node-version.test.js
+++ b/test/node-version.test.js
@@ -1,5 +1,4 @@
 const fs = require("fs");
-const assert = require("assert");
 const electronReleases = require("electron-releases/lite.json");
 const packageJson = require("../package.json");
 const packageLockJson = require("../package-lock.json");
@@ -13,12 +12,12 @@ describe("Node versions", () => {
 
   it(`should find node version ${nodeVersion} in .nvmrc`, () => {
     const nvmrc = fs.readFileSync("./.nvmrc", "utf-8");
-    assert.strictEqual(nvmrc, nodeVersion);
+    expect(nvmrc).toBe(nodeVersion);
   });
 
   it(`should find node version ${nodeVersion} in .travis.yml`, () => {
     const travisYml = fs.readFileSync("./.travis.yml", "utf-8");
-    const matches = travisYml.indexOf(`- "${nodeVersion}1"`) !== -1;
+    const matches = travisYml.indexOf(`- "${nodeVersion}"`) !== -1;
     const failMessage = matches
       ? undefined
       : [
@@ -29,7 +28,7 @@ describe("Node versions", () => {
   });
 
   it(`should find engines node version ${nodeVersion} in package.json`, () => {
-    assert.strictEqual(packageJson.engines.node, nodeVersion);
+    expect(packageJson.engines.node).toBe(nodeVersion);
   });
 });
 


### PR DESCRIPTION
As a developer
In order to have a really nice test runner and capabilities to mock modules using `jest.mock`
I want `jest` to be the test framework in mob-timer

This PR improves upon #44 

# What

- Move to `expect` assertions provided by jest
- Avoid accidental use of `assert` 