### PR TITLE
Add generous eslint size rules

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -27,6 +27,13 @@
         ]
       }
     ],
+    "complexity": "error",
+    "max-lines": [
+      "error",
+      700
+    ],
+    "max-depth": "error",
+    "max-params": "error",
     "no-restricted-modules": [
       "error",
       {


### PR DESCRIPTION
As a contributor to mob-timer
In order to get quick feedback on my changes
I want obvious room for improvement in my code to be highlighted by ESLint