### PR TITLE
Test config window initialize

### DIFF
--- a/__mocks__/electron.js
+++ b/__mocks__/electron.js
@@ -1,0 +1,3 @@
+module.exports = {
+  BrowserWindow: jest.fn()
+};

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
       "!src/**/*.test.js",
       "!src/**/test-*.js"
     ],
-    "collectCoverage": true
+    "collectCoverage": true,
+    "resetMocks": true
   },
   "repository": {
     "type": "git",

--- a/src/windows/config/initialize.js
+++ b/src/windows/config/initialize.js
@@ -1,18 +1,21 @@
 const { BrowserWindow } = require("electron");
 
-let configWindow;
+exports.initialize = () => {
+  let configWindow;
 
-exports.showConfigWindow = () => {
-  if (configWindow) {
-    configWindow.showWindow();
-    return;
-  }
-  configWindow = createConfigWindow();
-  configWindow.onClose(() => (configWindow = null));
-};
-
-exports.sendEventToConfigWindow = (event, data) => {
-  configWindow && configWindow.sendEvent(event, data);
+  return {
+    showConfigWindow: () => {
+      if (configWindow) {
+        configWindow.showWindow();
+        return;
+      }
+      configWindow = createConfigWindow();
+      configWindow.onClose(() => (configWindow = null));
+    },
+    sendEventToConfigWindow: (event, data) => {
+      configWindow && configWindow.sendEvent(event, data);
+    }
+  };
 };
 
 const createConfigWindow = () => {

--- a/src/windows/config/initialize.js
+++ b/src/windows/config/initialize.js
@@ -1,20 +1,14 @@
 const { BrowserWindow } = require("electron");
+const { asLazySingletonWindow } = require("../lazy-singleton-window");
 
 exports.initialize = () => {
-  let configWindow;
+  const { showWindow, trySendEvent } = asLazySingletonWindow(
+    createConfigWindow
+  );
 
   return {
-    showConfigWindow: () => {
-      if (configWindow) {
-        configWindow.showWindow();
-        return;
-      }
-      configWindow = createConfigWindow();
-      configWindow.onClose(() => (configWindow = null));
-    },
-    sendEventToConfigWindow: (event, data) => {
-      configWindow && configWindow.sendEvent(event, data);
-    }
+    showConfigWindow: showWindow,
+    sendEventToConfigWindow: trySendEvent
   };
 };
 
@@ -30,10 +24,5 @@ const createConfigWindow = () => {
 
   configWindowInstance.loadURL(`file://${__dirname}/index.html`);
 
-  return {
-    showWindow: () => configWindowInstance.show(),
-    onClose: callback => configWindowInstance.on("closed", callback),
-    sendEvent: (event, data) =>
-      configWindowInstance.webContents.send(event, data)
-  };
+  return configWindowInstance;
 };

--- a/src/windows/config/initialize.test.js
+++ b/src/windows/config/initialize.test.js
@@ -2,9 +2,6 @@ const { initialize } = require("./initialize");
 const mockElectron = require("electron");
 const mockLazySingletonWindow = require("../lazy-singleton-window");
 
-jest.mock("electron", () => ({
-  BrowserWindow: jest.fn()
-}));
 jest.mock("../lazy-singleton-window", () => ({
   asLazySingletonWindow: jest.fn()
 }));

--- a/src/windows/config/initialize.test.js
+++ b/src/windows/config/initialize.test.js
@@ -1,0 +1,206 @@
+const { initialize } = require("./initialize");
+const mockElectron = require("electron");
+
+jest.mock("electron", () => ({
+  BrowserWindow: jest.fn()
+}));
+
+describe("config window initialize", () => {
+  describe("showConfigWindow", () => {
+    it("should create BrowserWindow with correct configuration", () => {
+      mockElectron.BrowserWindow.mockImplementation(function() {
+        const invokedAsConstructor =
+          this.constructor.name === "mockConstructor";
+        if (!invokedAsConstructor) {
+          throw new Error(
+            "BrowserWindow not invoked as ctor, did you forget new?"
+          );
+        }
+        return { loadURL: () => {}, on: () => {} };
+      });
+
+      const configWindow = initialize();
+      configWindow.showConfigWindow();
+
+      expect(mockElectron.BrowserWindow).toHaveBeenCalledWith({
+        autoHideMenuBar: true,
+        height: 650,
+        webPreferences: { nodeIntegration: true },
+        width: 420
+      });
+    });
+
+    it("should load index.html after creating BrowserWindow", () => {
+      const mockLoadURL = jest.fn();
+      mockElectron.BrowserWindow.mockImplementation(function() {
+        const invokedAsConstructor =
+          this.constructor.name === "mockConstructor";
+        if (!invokedAsConstructor) {
+          throw new Error(
+            "BrowserWindow not invoked as ctor, did you forget new?"
+          );
+        }
+        return { loadURL: mockLoadURL, on: () => {} };
+      });
+
+      const configWindow = initialize();
+      configWindow.showConfigWindow();
+
+      expect(mockLoadURL).toHaveBeenCalledWith(
+        expect.stringContaining("config/index.html")
+      );
+    });
+
+    it("should re-open same BrowserWindow if not closed", () => {
+      const mockLoadURL = jest.fn();
+      const mockShow = jest.fn();
+      mockElectron.BrowserWindow.mockImplementation(function() {
+        const invokedAsConstructor =
+          this.constructor.name === "mockConstructor";
+        if (!invokedAsConstructor) {
+          throw new Error(
+            "BrowserWindow not invoked as ctor, did you forget new?"
+          );
+        }
+        return { loadURL: mockLoadURL, on: () => {}, show: mockShow };
+      });
+
+      const configWindow = initialize();
+      configWindow.showConfigWindow();
+      configWindow.showConfigWindow();
+
+      expect(mockShow).toHaveBeenCalledTimes(1);
+    });
+
+    it("should create new BrowserWindow if old is closed", () => {
+      const mockLoadURL = jest.fn();
+      const mockShow = jest.fn();
+      const mockOn = jest.fn();
+      mockElectron.BrowserWindow.mockImplementation(function() {
+        const invokedAsConstructor =
+          this.constructor.name === "mockConstructor";
+        if (!invokedAsConstructor) {
+          throw new Error(
+            "BrowserWindow not invoked as ctor, did you forget new?"
+          );
+        }
+        return { loadURL: mockLoadURL, on: mockOn, show: mockShow };
+      });
+
+      const configWindow = initialize();
+      configWindow.showConfigWindow();
+      simulateEvent(mockOn, "closed");
+      configWindow.showConfigWindow();
+
+      const mockCallCounts = {
+        BrowserWindow: mockElectron.BrowserWindow.mock.calls.length,
+        BrowserWindowLoadURL: mockLoadURL.mock.calls.length,
+        BrowserWindowShow: mockShow.mock.calls.length
+      };
+      expect(mockCallCounts).toEqual({
+        BrowserWindow: 2,
+        BrowserWindowLoadURL: 2,
+        BrowserWindowShow: 0
+      });
+    });
+
+    it("should send event to BrowserWindow webContents", () => {
+      const mockLoadURL = jest.fn();
+      const mockShow = jest.fn();
+      const mockOn = jest.fn();
+      const mockWebContentsSend = jest.fn();
+      mockElectron.BrowserWindow.mockImplementation(function() {
+        const invokedAsConstructor =
+          this.constructor.name === "mockConstructor";
+        if (!invokedAsConstructor) {
+          throw new Error(
+            "BrowserWindow not invoked as ctor, did you forget new?"
+          );
+        }
+        return {
+          loadURL: mockLoadURL,
+          on: mockOn,
+          show: mockShow,
+          webContents: {
+            send: mockWebContentsSend
+          }
+        };
+      });
+
+      const configWindow = initialize();
+      configWindow.showConfigWindow();
+      configWindow.sendEventToConfigWindow("fake-event", "fake-event-data");
+
+      expect(mockWebContentsSend).toHaveBeenCalledWith(
+        "fake-event",
+        "fake-event-data"
+      );
+    });
+
+    it("should not send event if there never was a BrowserWindow", () => {
+      const mockLoadURL = jest.fn();
+      const mockShow = jest.fn();
+      const mockOn = jest.fn();
+      const mockWebContentsSend = jest.fn();
+      mockElectron.BrowserWindow.mockImplementation(function() {
+        const invokedAsConstructor =
+          this.constructor.name === "mockConstructor";
+        if (!invokedAsConstructor) {
+          throw new Error(
+            "BrowserWindow not invoked as ctor, did you forget new?"
+          );
+        }
+        return {
+          loadURL: mockLoadURL,
+          on: mockOn,
+          show: mockShow,
+          webContents: {
+            send: mockWebContentsSend
+          }
+        };
+      });
+
+      const configWindow = initialize();
+      configWindow.sendEventToConfigWindow("fake-event", "fake-event-data");
+
+      expect(mockWebContentsSend).not.toHaveBeenCalled();
+    });
+
+    it("should not send event if BrowserWindow has closed", () => {
+      const mockLoadURL = jest.fn();
+      const mockShow = jest.fn();
+      const mockOn = jest.fn();
+      const mockWebContentsSend = jest.fn();
+      mockElectron.BrowserWindow.mockImplementation(function() {
+        const invokedAsConstructor =
+          this.constructor.name === "mockConstructor";
+        if (!invokedAsConstructor) {
+          throw new Error(
+            "BrowserWindow not invoked as ctor, did you forget new?"
+          );
+        }
+        return {
+          loadURL: mockLoadURL,
+          on: mockOn,
+          show: mockShow,
+          webContents: {
+            send: mockWebContentsSend
+          }
+        };
+      });
+
+      const configWindow = initialize();
+      configWindow.showConfigWindow();
+      simulateEvent(mockOn, "closed");
+      configWindow.sendEventToConfigWindow("fake-event", "fake-event-data");
+
+      expect(mockWebContentsSend).not.toHaveBeenCalled();
+    });
+
+    const simulateEvent = (mockOn, eventName) => {
+      mockOn.mock.calls
+        .filter(args => args[0] === eventName)
+        .forEach(args => args[1]());
+    };
+  });
+});

--- a/src/windows/config/initialize.test.js
+++ b/src/windows/config/initialize.test.js
@@ -69,7 +69,9 @@ describe("config window initialize", () => {
         BrowserWindowShow: 0
       });
     });
+  });
 
+  describe("sendEventToConfigWindow", () => {
     it("should send event to BrowserWindow webContents", () => {
       const { mockWebContentsSend } = mockBrowserWindowConstructor(
         mockElectron.BrowserWindow
@@ -109,40 +111,39 @@ describe("config window initialize", () => {
 
       expect(mockWebContentsSend).not.toHaveBeenCalled();
     });
+  });
 
-    const mockBrowserWindowConstructor = mockBrowserWindow => {
-      const mockLoadURL = jest.fn();
-      const mockOn = jest.fn();
-      const mockShow = jest.fn();
-      const mockWebContentsSend = jest.fn();
-      mockBrowserWindow.mockImplementation(function() {
-        const invokedAsConstructor =
-          this.constructor.name === "mockConstructor";
-        if (!invokedAsConstructor) {
-          throw new Error(
-            "BrowserWindow not invoked as ctor, did you forget new?"
-          );
-        }
-        return {
-          loadURL: mockLoadURL,
-          on: mockOn,
-          show: mockShow,
-          webContents: {
-            send: mockWebContentsSend
-          }
-        };
-      });
-
+  const mockBrowserWindowConstructor = mockBrowserWindow => {
+    const mockLoadURL = jest.fn();
+    const mockOn = jest.fn();
+    const mockShow = jest.fn();
+    const mockWebContentsSend = jest.fn();
+    mockBrowserWindow.mockImplementation(function() {
+      const invokedAsConstructor = this.constructor.name === "mockConstructor";
+      if (!invokedAsConstructor) {
+        throw new Error(
+          "BrowserWindow not invoked as ctor, did you forget new?"
+        );
+      }
       return {
-        mockLoadURL,
-        mockShow,
-        mockWebContentsSend,
-        simulateEvent: eventName => {
-          mockOn.mock.calls
-            .filter(args => args[0] === eventName)
-            .forEach(args => args[1]());
+        loadURL: mockLoadURL,
+        on: mockOn,
+        show: mockShow,
+        webContents: {
+          send: mockWebContentsSend
         }
       };
+    });
+
+    return {
+      mockLoadURL,
+      mockShow,
+      mockWebContentsSend,
+      simulateEvent: eventName => {
+        mockOn.mock.calls
+          .filter(args => args[0] === eventName)
+          .forEach(args => args[1]());
+      }
     };
-  });
+  };
 });

--- a/src/windows/config/initialize.test.js
+++ b/src/windows/config/initialize.test.js
@@ -1,149 +1,99 @@
 const { initialize } = require("./initialize");
 const mockElectron = require("electron");
+const mockLazySingletonWindow = require("../lazy-singleton-window");
 
 jest.mock("electron", () => ({
   BrowserWindow: jest.fn()
 }));
+jest.mock("../lazy-singleton-window", () => ({
+  asLazySingletonWindow: jest.fn()
+}));
 
 describe("config window initialize", () => {
-  describe("showConfigWindow", () => {
-    it("should create BrowserWindow with correct configuration", () => {
-      mockBrowserWindowConstructor(mockElectron.BrowserWindow);
+  describe("initialization", () => {
+    it("should prepare for creating singleton window", () => {
+      const mockShowWindow = jest.fn();
+      const mockTrySendEvent = jest.fn();
+      mockLazySingletonWindow.asLazySingletonWindow.mockImplementation(() => ({
+        showWindow: mockShowWindow,
+        trySendEvent: mockTrySendEvent
+      }));
 
       const configWindow = initialize();
-      configWindow.showConfigWindow();
 
-      expect(mockElectron.BrowserWindow).toHaveBeenCalledWith({
-        autoHideMenuBar: true,
-        height: 650,
-        webPreferences: { nodeIntegration: true },
-        width: 420
+      expect(configWindow).toEqual({
+        showConfigWindow: mockShowWindow,
+        sendEventToConfigWindow: mockTrySendEvent
       });
     });
 
-    it("should load index.html after creating BrowserWindow", () => {
-      const { mockLoadURL } = mockBrowserWindowConstructor(
-        mockElectron.BrowserWindow
-      );
-
-      const configWindow = initialize();
-      configWindow.showConfigWindow();
-
-      expect(mockLoadURL).toHaveBeenCalledWith(
-        expect.stringContaining("config/index.html")
-      );
-    });
-
-    it("should re-open same BrowserWindow if not closed", () => {
-      const { mockShow } = mockBrowserWindowConstructor(
-        mockElectron.BrowserWindow
-      );
-
-      const configWindow = initialize();
-      configWindow.showConfigWindow();
-      configWindow.showConfigWindow();
-
-      expect(mockShow).toHaveBeenCalledTimes(1);
-    });
-
-    it("should create new BrowserWindow if old is closed", () => {
-      const {
-        mockLoadURL,
-        mockShow,
-        simulateEvent
-      } = mockBrowserWindowConstructor(mockElectron.BrowserWindow);
-
-      const configWindow = initialize();
-      configWindow.showConfigWindow();
-      simulateEvent("closed");
-      configWindow.showConfigWindow();
-
-      const mockCallCounts = {
-        BrowserWindow: mockElectron.BrowserWindow.mock.calls.length,
-        BrowserWindowLoadURL: mockLoadURL.mock.calls.length,
-        BrowserWindowShow: mockShow.mock.calls.length
-      };
-      expect(mockCallCounts).toEqual({
-        BrowserWindow: 2,
-        BrowserWindowLoadURL: 2,
-        BrowserWindowShow: 0
-      });
-    });
-  });
-
-  describe("sendEventToConfigWindow", () => {
-    it("should send event to BrowserWindow webContents", () => {
-      const { mockWebContentsSend } = mockBrowserWindowConstructor(
-        mockElectron.BrowserWindow
-      );
-
-      const configWindow = initialize();
-      configWindow.showConfigWindow();
-      configWindow.sendEventToConfigWindow("fake-event", "fake-event-data");
-
-      expect(mockWebContentsSend).toHaveBeenCalledWith(
-        "fake-event",
-        "fake-event-data"
-      );
-    });
-
-    it("should not send event if there never was a BrowserWindow", () => {
-      const { mockWebContentsSend } = mockBrowserWindowConstructor(
-        mockElectron.BrowserWindow
-      );
-
-      const configWindow = initialize();
-      configWindow.sendEventToConfigWindow("fake-event", "fake-event-data");
-
-      expect(mockWebContentsSend).not.toHaveBeenCalled();
-    });
-
-    it("should not send event if BrowserWindow has closed", () => {
-      const {
-        mockWebContentsSend,
-        simulateEvent
-      } = mockBrowserWindowConstructor(mockElectron.BrowserWindow);
-
-      const configWindow = initialize();
-      configWindow.showConfigWindow();
-      simulateEvent("closed");
-      configWindow.sendEventToConfigWindow("fake-event", "fake-event-data");
-
-      expect(mockWebContentsSend).not.toHaveBeenCalled();
-    });
-  });
-
-  const mockBrowserWindowConstructor = mockBrowserWindow => {
-    const mockLoadURL = jest.fn();
-    const mockOn = jest.fn();
-    const mockShow = jest.fn();
-    const mockWebContentsSend = jest.fn();
-    mockBrowserWindow.mockImplementation(function() {
-      const invokedAsConstructor = this.constructor.name === "mockConstructor";
-      if (!invokedAsConstructor) {
-        throw new Error(
-          "BrowserWindow not invoked as ctor, did you forget new?"
+    describe("createBrowserWindow factory", () => {
+      it("should create BrowserWindow with correct configuration", () => {
+        const mockShowWindow = jest.fn();
+        const mockTrySendEvent = jest.fn();
+        mockLazySingletonWindow.asLazySingletonWindow.mockImplementation(
+          () => ({
+            showWindow: mockShowWindow,
+            trySendEvent: mockTrySendEvent
+          })
         );
-      }
-      return {
-        loadURL: mockLoadURL,
-        on: mockOn,
-        show: mockShow,
-        webContents: {
-          send: mockWebContentsSend
-        }
+        mockBrowserWindowConstructor(mockElectron.BrowserWindow);
+        initialize();
+        const createBrowserWindow =
+          mockLazySingletonWindow.asLazySingletonWindow.mock.calls[0][0];
+
+        createBrowserWindow();
+
+        expect(mockElectron.BrowserWindow).toHaveBeenCalledWith({
+          autoHideMenuBar: true,
+          height: 650,
+          webPreferences: { nodeIntegration: true },
+          width: 420
+        });
+      });
+
+      it("should load index.html after creating BrowserWindow", () => {
+        const mockShowWindow = jest.fn();
+        const mockTrySendEvent = jest.fn();
+        mockLazySingletonWindow.asLazySingletonWindow.mockImplementation(
+          () => ({
+            showWindow: mockShowWindow,
+            trySendEvent: mockTrySendEvent
+          })
+        );
+        const { mockLoadURL } = mockBrowserWindowConstructor(
+          mockElectron.BrowserWindow
+        );
+        initialize();
+        const createBrowserWindow =
+          mockLazySingletonWindow.asLazySingletonWindow.mock.calls[0][0];
+
+        createBrowserWindow();
+
+        expect(mockLoadURL).toHaveBeenCalledWith(
+          expect.stringContaining("config/index.html")
+        );
+      });
+
+      const mockBrowserWindowConstructor = mockBrowserWindow => {
+        const mockLoadURL = jest.fn();
+        mockBrowserWindow.mockImplementation(function() {
+          const invokedAsConstructor =
+            this.constructor.name === "mockConstructor";
+          if (!invokedAsConstructor) {
+            throw new Error(
+              "BrowserWindow not invoked as ctor, did you forget new?"
+            );
+          }
+          return {
+            loadURL: mockLoadURL
+          };
+        });
+
+        return {
+          mockLoadURL
+        };
       };
     });
-
-    return {
-      mockLoadURL,
-      mockShow,
-      mockWebContentsSend,
-      simulateEvent: eventName => {
-        mockOn.mock.calls
-          .filter(args => args[0] === eventName)
-          .forEach(args => args[1]());
-      }
-    };
-  };
+  });
 });

--- a/src/windows/config/initialize.test.js
+++ b/src/windows/config/initialize.test.js
@@ -11,12 +11,9 @@ jest.mock("../lazy-singleton-window", () => ({
 
 describe("config window initialize", () => {
   it("should prepare for creating singleton window", () => {
-    const mockShowWindow = jest.fn();
-    const mockTrySendEvent = jest.fn();
-    mockLazySingletonWindow.asLazySingletonWindow.mockImplementation(() => ({
-      showWindow: mockShowWindow,
-      trySendEvent: mockTrySendEvent
-    }));
+    const { mockShowWindow, mockTrySendEvent } = mockAsLazySingletonWindow(
+      mockLazySingletonWindow.asLazySingletonWindow
+    );
 
     const configWindow = initialize();
 
@@ -28,18 +25,13 @@ describe("config window initialize", () => {
 
   describe("createBrowserWindow factory", () => {
     it("should create BrowserWindow with correct configuration", () => {
-      const mockShowWindow = jest.fn();
-      const mockTrySendEvent = jest.fn();
-      mockLazySingletonWindow.asLazySingletonWindow.mockImplementation(() => ({
-        showWindow: mockShowWindow,
-        trySendEvent: mockTrySendEvent
-      }));
+      const { invokeCreateBrowserWindow } = mockAsLazySingletonWindow(
+        mockLazySingletonWindow.asLazySingletonWindow
+      );
       mockBrowserWindowConstructor(mockElectron.BrowserWindow);
       initialize();
-      const createBrowserWindow =
-        mockLazySingletonWindow.asLazySingletonWindow.mock.calls[0][0];
 
-      createBrowserWindow();
+      invokeCreateBrowserWindow();
 
       expect(mockElectron.BrowserWindow).toHaveBeenCalledWith({
         autoHideMenuBar: true,
@@ -50,20 +42,15 @@ describe("config window initialize", () => {
     });
 
     it("should load index.html after creating BrowserWindow", () => {
-      const mockShowWindow = jest.fn();
-      const mockTrySendEvent = jest.fn();
-      mockLazySingletonWindow.asLazySingletonWindow.mockImplementation(() => ({
-        showWindow: mockShowWindow,
-        trySendEvent: mockTrySendEvent
-      }));
+      const { invokeCreateBrowserWindow } = mockAsLazySingletonWindow(
+        mockLazySingletonWindow.asLazySingletonWindow
+      );
       const { mockLoadURL } = mockBrowserWindowConstructor(
         mockElectron.BrowserWindow
       );
       initialize();
-      const createBrowserWindow =
-        mockLazySingletonWindow.asLazySingletonWindow.mock.calls[0][0];
 
-      createBrowserWindow();
+      invokeCreateBrowserWindow();
 
       expect(mockLoadURL).toHaveBeenCalledWith(
         expect.stringContaining("config/index.html")
@@ -90,4 +77,22 @@ describe("config window initialize", () => {
       };
     };
   });
+
+  const mockAsLazySingletonWindow = asLazySingletonWindow => {
+    const mockShowWindow = jest.fn();
+    const mockTrySendEvent = jest.fn();
+    asLazySingletonWindow.mockImplementation(() => ({
+      showWindow: mockShowWindow,
+      trySendEvent: mockTrySendEvent
+    }));
+
+    return {
+      mockShowWindow,
+      mockTrySendEvent,
+      invokeCreateBrowserWindow: () => {
+        const createBrowserWindow = asLazySingletonWindow.mock.calls[0][0];
+        createBrowserWindow();
+      }
+    };
+  };
 });

--- a/src/windows/lazy-singleton-window.js
+++ b/src/windows/lazy-singleton-window.js
@@ -1,0 +1,16 @@
+exports.asLazySingletonWindow = createBrowserWindow => {
+  let browserWindow;
+
+  return {
+    showWindow: () => {
+      if (browserWindow) {
+        browserWindow.show();
+        return;
+      }
+      browserWindow = createBrowserWindow();
+      browserWindow.on("closed", () => (browserWindow = undefined));
+    },
+    trySendEvent: (event, data) =>
+      browserWindow && browserWindow.webContents.send(event, data)
+  };
+};

--- a/src/windows/lazy-singleton-window.test.js
+++ b/src/windows/lazy-singleton-window.test.js
@@ -1,0 +1,114 @@
+const { asLazySingletonWindow } = require("./lazy-singleton-window");
+
+describe("asLazySingletonWindow", () => {
+  describe("initialization", () => {
+    it("should not create BrowserWindow directly", () => {
+      const { mockCreateBrowserWindow } = setup();
+
+      asLazySingletonWindow(mockCreateBrowserWindow);
+
+      expect(mockCreateBrowserWindow).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("showWindow", () => {
+    it("should create BrowserWindow when showWindow called", () => {
+      const { mockCreateBrowserWindow } = setup();
+
+      const singletonWindow = asLazySingletonWindow(mockCreateBrowserWindow);
+      singletonWindow.showWindow();
+
+      expect(mockCreateBrowserWindow).toHaveBeenCalledTimes(1);
+    });
+
+    it("should re-open same BrowserWindow if not closed", () => {
+      const { mockCreateBrowserWindow, mockShow } = setup();
+
+      const singletonWindow = asLazySingletonWindow(mockCreateBrowserWindow);
+      singletonWindow.showWindow();
+      singletonWindow.showWindow();
+
+      expect(mockShow).toHaveBeenCalledTimes(1);
+    });
+
+    it("should create new BrowserWindow if old is closed", () => {
+      const { mockCreateBrowserWindow, mockShow, simulateEvent } = setup();
+
+      const singletonWindow = asLazySingletonWindow(mockCreateBrowserWindow);
+      singletonWindow.showWindow();
+      simulateEvent("closed");
+      singletonWindow.showWindow();
+
+      const mockCallCounts = {
+        createBrowserWindow: mockCreateBrowserWindow.mock.calls.length,
+        BrowserWindowShow: mockShow.mock.calls.length
+      };
+      expect(mockCallCounts).toEqual({
+        createBrowserWindow: 2,
+        BrowserWindowShow: 0
+      });
+    });
+  });
+
+  describe("trySendEvent", () => {
+    it("should send event to BrowserWindow webContents", () => {
+      const { mockCreateBrowserWindow, mockWebContentsSend } = setup();
+
+      const singletonWindow = asLazySingletonWindow(mockCreateBrowserWindow);
+      singletonWindow.showWindow();
+      singletonWindow.trySendEvent("fake-event", "fake-event-data");
+
+      expect(mockWebContentsSend).toHaveBeenCalledWith(
+        "fake-event",
+        "fake-event-data"
+      );
+    });
+
+    it("should not send event if there never was a BrowserWindow", () => {
+      const { mockCreateBrowserWindow, mockWebContentsSend } = setup();
+
+      const singletonWindow = asLazySingletonWindow(mockCreateBrowserWindow);
+      singletonWindow.trySendEvent("fake-event", "fake-event-data");
+
+      expect(mockWebContentsSend).not.toHaveBeenCalled();
+    });
+
+    it("should not send event if BrowserWindow has closed", () => {
+      const {
+        mockCreateBrowserWindow,
+        simulateEvent,
+        mockWebContentsSend
+      } = setup();
+
+      const singletonWindow = asLazySingletonWindow(mockCreateBrowserWindow);
+      singletonWindow.showWindow();
+      simulateEvent("closed");
+      singletonWindow.trySendEvent("fake-event", "fake-event-data");
+
+      expect(mockWebContentsSend).not.toHaveBeenCalled();
+    });
+  });
+
+  const setup = () => {
+    const mockOn = jest.fn();
+    const mockShow = jest.fn();
+    const mockWebContentsSend = jest.fn();
+
+    return {
+      mockCreateBrowserWindow: jest.fn(() => ({
+        on: mockOn,
+        show: mockShow,
+        webContents: {
+          send: mockWebContentsSend
+        }
+      })),
+      mockShow,
+      mockWebContentsSend,
+      simulateEvent: eventName => {
+        mockOn.mock.calls
+          .filter(args => args[0] === eventName)
+          .forEach(args => args[1]());
+      }
+    };
+  };
+});

--- a/src/windows/windows.js
+++ b/src/windows/windows.js
@@ -6,7 +6,7 @@ const { debounce } = require("debounce");
 const {
   showConfigWindow,
   sendEventToConfigWindow
-} = require("./config/initialize");
+} = require("./config/initialize").initialize();
 
 let timerWindow, fullscreenWindow;
 let snapThreshold, secondsUntilFullscreen, timerAlwaysOnTop;


### PR DESCRIPTION
As a developer
In order to feel more confident when making changes
I want the code to have adequate tests

As a developer
In order to validate that I have written testable code
I want the code to have adequate tests

# Lessons from testing

- Encapsulating state in function closures and not directly in the module helps with testability
- The singleton window function could be generalized going forward
- Should the state live in `config/initialize.js` or in `windows.js`? Somewhere else?