### PR TITLE
Move away from SetInterval to Date.now

### DIFF
--- a/src/state/timer-state.js
+++ b/src/state/timer-state.js
@@ -50,7 +50,7 @@ class TimerState {
 
   dispatchTimerChange(secondsRemaining) {
     this.callback("timerChange", {
-      secondsRemaining,
+      secondsRemaining: secondsRemaining < 0 ? 0 : secondsRemaining,
       secondsPerTurn: this.secondsPerTurn
     });
   }

--- a/src/state/timer.js
+++ b/src/state/timer.js
@@ -2,15 +2,24 @@ class Timer {
   constructor(options, callback) {
     this.rateMilliseconds = options.rateMilliseconds || 1000;
     this.time = options.time || 0;
-    this.change = options.countDown ? -1 : 1;
+    this.timeDelta = 0;
+    this.countDown = options.countDown === true;
     this.callback = callback;
+    this.startingTime = null;
   }
 
-  start() {
+  start(now = Date.now) {
+    this.startingTime = now();
+
     if (!this.interval) {
       this.interval = setInterval(() => {
-        this.time += this.change;
-        this.callback(this.time);
+        const secondsPassed = Math.floor((now() - this.startingTime) / 1000);
+        this.timeDelta = secondsPassed;
+        const secondsRemaining = this.time - secondsPassed;
+
+        this.callback(
+          this.countDown ? secondsRemaining : secondsPassed + this.time
+        );
       }, this.rateMilliseconds);
     }
   }
@@ -20,10 +29,16 @@ class Timer {
       clearInterval(this.interval);
       this.interval = null;
     }
+    this.countDown
+      ? (this.time = this.time - this.timeDelta)
+      : (this.time += this.timeDelta);
+    this.timeDelta = 0;
   }
 
-  reset(value) {
+  reset(value, now = Date.now) {
     this.time = value;
+    this.timeDelta = 0;
+    this.startingTime = now();
   }
 }
 

--- a/src/state/timer.test.js
+++ b/src/state/timer.test.js
@@ -7,6 +7,14 @@ describe("Timer", () => {
   let callbacks;
   let clock;
 
+  const mockDateNow = () => {
+    let calls = 0;
+    return () => {
+      calls++;
+      return calls * 1000;
+    };
+  };
+
   let createTimer = () => {
     timer = new Timer(timerOptions, x => callbacks.push(x));
   };
@@ -33,8 +41,8 @@ describe("Timer", () => {
         expect(timer.time).toBe(timerOptions.time);
       });
 
-      it("should have a change value based on the specified countDown", () => {
-        expect(timer.change).toBe(-1);
+      it("should know if it is counting up or down based on the specified countDown", () => {
+        expect(timer.countDown).toBe(true);
       });
     });
 
@@ -52,15 +60,15 @@ describe("Timer", () => {
         expect(timer.time).toBe(0);
       });
 
-      it("should have the default change value", () => {
-        expect(timer.change).toBe(1);
+      it("should have the default countDown value", () => {
+        expect(timer.countDown).toBe(false);
       });
     });
   });
 
   describe("start", () => {
     it("should generate callbacks when counting down", () => {
-      timer.start();
+      timer.start(mockDateNow());
       clock.tick(50);
       expect(callbacks.join(",")).toBe("49,48");
     });
@@ -68,7 +76,7 @@ describe("Timer", () => {
     it("should generate callbacks when counting up", () => {
       timerOptions.countDown = false;
       createTimer();
-      timer.start();
+      timer.start(mockDateNow());
       clock.tick(50);
       expect(callbacks.join(",")).toBe("51,52");
     });
@@ -76,7 +84,7 @@ describe("Timer", () => {
 
   describe("pause", () => {
     it("should stop further callbacks from occuring", () => {
-      timer.start();
+      timer.start(mockDateNow());
       clock.tick(50);
       timer.pause();
       clock.tick(100);
@@ -91,9 +99,10 @@ describe("Timer", () => {
     });
 
     it("should set a new time value when the timer is running", () => {
-      timer.start();
+      const mockedDateNow = mockDateNow();
+      timer.start(mockedDateNow);
       clock.tick(50);
-      timer.reset(20);
+      timer.reset(20, mockedDateNow);
       clock.tick(40);
       expect(callbacks.join(",")).toBe("49,48,19,18");
     });


### PR DESCRIPTION
When offscreen (IE in another macOs desktop), the mob timer has a tendancy to drift wildly, making turns last minutes longer than they should.

This commit/pull request moves away from trusting the SetInterval callback to be called every second, and instead relies on computed time differences using Javascript's Date object.

Cherry picked from https://github.com/pluralsight/mob-timer/commit/4328f56dd6f717ebfab430eb0051b022a6c62d31 and adjusted to fit code base