### PR TITLE
Remove mentions of Greenkeeper

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Mob Timer
 
 [![GitHub release](https://img.shields.io/github/release/mob-timer/mob-timer.svg)](https://github.com/mob-timer/mob-timer/releases)
-[![Greenkeeper badge](https://badges.greenkeeper.io/mob-timer/mob-timer.svg)](https://greenkeeper.io/)
 [![License](https://img.shields.io/github/license/mob-timer/mob-timer.svg)](LICENSE)
 [![GitHub contributors](https://img.shields.io/github/contributors/mob-timer/mob-timer.svg)](https://github.com/mob-timer/mob-timer/graphs/contributors)
 [![Travis (.org)](https://img.shields.io/travis/mob-timer/mob-timer/master.svg)](https://travis-ci.org/mob-timer/mob-timer/branches)
@@ -52,7 +51,6 @@ _This is a fork from [pluralsight/mob-timer](https://github.com/pluralsight/mob-
 There are a few main reasons for this fork existing:
 
 - To build in CI and attach to release using [Travis CI](https://travis-ci.org/)
-- To stay up to date with dependencies using [Greenkeeper.io](https://greenkeeper.io/)
 - To move to code style and tooling suited for project, not needing to take internal company best practices into account
 - To have an independent organization where the mob-timer is the focus
 


### PR DESCRIPTION
The beloved tool greenkeeper has merged into Snyk.
We will evaluate Dependabot which was aquired by Github and is integrated nicely in github.