### PR TITLE
Update global unique identifier package from v3 to v8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2445,6 +2445,14 @@
             "tough-cookie": "~2.5.0",
             "tunnel-agent": "^0.6.0",
             "uuid": "^3.3.2"
+          },
+          "dependencies": {
+            "uuid": {
+              "version": "3.4.0",
+              "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+              "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+              "dev": true
+            }
           }
         },
         "tough-cookie": {
@@ -7446,6 +7454,14 @@
         "tough-cookie": "~2.4.3",
         "tunnel-agent": "^0.6.0",
         "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+          "dev": true
+        }
       }
     },
     "request-promise-core": {
@@ -8935,9 +8951,9 @@
       }
     },
     "uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.0.tgz",
+      "integrity": "sha512-fX6Z5o4m6XsXBdli9g7DtWgAx+osMsRRZFKma1mIUsLCz6vRvv+pz5VNbyu9UEDzpMWulZfvpgb/cmDXVulYFQ=="
     },
     "v8-compile-cache": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -84,6 +84,6 @@
     "electron-reload": "^1.5.0",
     "pretty-checkbox": "^3.0.3",
     "typeface-work-sans": "0.0.72",
-    "uuid": "^3.4.0"
+    "uuid": "^8.3.0"
   }
 }

--- a/src/state/mobbers.js
+++ b/src/state/mobbers.js
@@ -1,4 +1,4 @@
-const newGuid = require("uuid/v4");
+const { v4: newGuid } = require("uuid");
 
 class Mobbers {
   constructor() {


### PR DESCRIPTION
https://www.npmjs.com/package/uuid#upgrading-from-uuid3x

As a developer
In order to have better support and documentation
I want to have up to date dependencies